### PR TITLE
♻️ replace `spectator` team references with `spectator_box` tag

### DIFF
--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/soul/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/soul/initialize.mcfunction
@@ -6,7 +6,7 @@ scoreboard players set @s omegaflowey.boss-fight.progress.clock.total 27
 function omegaflowey.entity:directorial/boss_fight/shared/phase/soul/static with storage omegaflowey:bossfight
 
 # # Move players to soul arena
-# execute as @a at @s unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] run function omegaflowey.entity:directorial/boss_fight/summit/origin/to_soul_origin
+# execute as @a at @s unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] run function omegaflowey.entity:directorial/boss_fight/summit/origin/to_soul_origin
 
 # Add tags
 tag @s add boss_fight.phase.soul

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/soul/terminate.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/soul/terminate.mcfunction
@@ -13,7 +13,7 @@ tag @s remove boss_fight.phase.soul
 function omegaflowey.entity:directorial/boss_fight/summit/phase/attack/initialize
 
 # # Move players to main arena
-# execute as @a at @s unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] run function omegaflowey.entity:directorial/boss_fight/summit/soul_origin/to_origin
+# execute as @a at @s unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] run function omegaflowey.entity:directorial/boss_fight/summit/soul_origin/to_origin
 
 # Re-summon main Omega Flowey models
 scoreboard players set #omegaflowey.bossfight.skip_resummon_tvscreen omegaflowey.global.flag 1

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/phase/soul/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/phase/soul/initialize.mcfunction
@@ -9,7 +9,7 @@ scoreboard players set @s omegaflowey.boss-fight.progress.clock.total 27
 function omegaflowey.entity:directorial/boss_fight/vanilla/phase/soul/static
 
 # Move players to soul arena
-execute as @a at @s unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] run teleport @s ~ ~ ~-75.0
+execute as @a at @s unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] run teleport @s ~ ~ ~-75.0
 
 # Add tags
 tag @s add boss_fight.phase.soul

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/phase/soul/terminate.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/phase/soul/terminate.mcfunction
@@ -5,7 +5,7 @@ tag @s remove boss_fight.phase.soul
 function omegaflowey.entity:directorial/boss_fight/vanilla/phase/attack/initialize
 
 # Move players to main arena
-execute as @a at @s unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] run teleport @s ~ ~ ~75.0
+execute as @a at @s unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] run teleport @s ~ ~ ~75.0
 
 # Re-summon main Omega Flowey models
 function omegaflowey.entity:hostile/omega-flowey/summon

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/after_bounce_as_bullet_head.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/after_bounce_as_bullet_head.mcfunction
@@ -1,4 +1,4 @@
 # If we bounced, play bounce sound
 # Only the bullet-head makes bounce sounds/shakes the player's screen (see `maybe_bounce.mcfunction`)
 playsound omega-flowey:attack.dentata-snakes.bounce hostile @a ~ ~ ~ 5 1
-# execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey,team=!dead,team=!spectator] at @s run function omegaflowey.entity:utils/shake_screen
+# execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey,team=!dead,tag=!omegaflowey.player.room.spectator_box] at @s run function omegaflowey.entity:utils/shake_screen

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines-save-states/executor/states/load_all_states/show_title.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines-save-states/executor/states/load_all_states/show_title.mcfunction
@@ -1,1 +1,1 @@
-execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] run function omegaflowey.entity:hostile/omega-flowey/attack/homing-vines-save-states/executor/states/load_all_states/show_title/as_player
+execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] run function omegaflowey.entity:hostile/omega-flowey/attack/homing-vines-save-states/executor/states/load_all_states/show_title/as_player

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines-save-states/executor/states/save_all_states/show_title.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines-save-states/executor/states/save_all_states/show_title.mcfunction
@@ -1,1 +1,1 @@
-execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] run function omegaflowey.entity:hostile/omega-flowey/attack/homing-vines-save-states/executor/states/save_all_states/show_title/as_player
+execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] run function omegaflowey.entity:hostile/omega-flowey/attack/homing-vines-save-states/executor/states/save_all_states/show_title/as_player

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-upper-save-states/executor/states/load_all_states/show_title.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-upper-save-states/executor/states/load_all_states/show_title.mcfunction
@@ -1,1 +1,1 @@
-execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] run function omegaflowey.entity:hostile/omega-flowey/attack/x-bullets-upper-save-states/executor/states/load_all_states/show_title/as_player
+execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] run function omegaflowey.entity:hostile/omega-flowey/attack/x-bullets-upper-save-states/executor/states/load_all_states/show_title/as_player

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-upper-save-states/executor/states/save_all_states/show_title.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-upper-save-states/executor/states/save_all_states/show_title.mcfunction
@@ -1,1 +1,1 @@
-execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] run function omegaflowey.entity:hostile/omega-flowey/attack/x-bullets-upper-save-states/executor/states/save_all_states/show_title/as_player
+execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] run function omegaflowey.entity:hostile/omega-flowey/attack/x-bullets-upper-save-states/executor/states/save_all_states/show_title/as_player

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/initialize/saved.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/initialize/saved.mcfunction
@@ -8,8 +8,8 @@ stopsound @a record omega-flowey:music.soul.0
 playsound omega-flowey:soul.saved record @a ~ ~ ~ 10 1
 playsound omega-flowey:soul.transition record @a ~ ~ ~ 10 1
 
-# Flash each player/spectator's screen
-execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] at @s anchored eyes run particle minecraft:flash ^ ^ ^0.5
+# Flash each player's screen
+execute as @a[tag=omegaflowey.player.fighting_flowey] at @s anchored eyes run particle minecraft:flash ^ ^ ^0.5
 
 # Initialize other soul event models
 execute as @e[tag=soul_0,tag=act-button] run function omegaflowey.entity:soul/soul_0/act_button/initialize/saved

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/initialize.mcfunction
@@ -13,6 +13,7 @@ scoreboard players set #omegaflowey.soul.5.touched omegaflowey.soul.flag 0
 function gu:generate
 data modify storage omegaflowey:soul.5 executor_uuid set from storage gu:main out
 
+data modify storage omegaflowey:soul.5 active_player_uuid set from storage omegaflowey:bossfight active_player_uuid
 data modify storage omegaflowey:soul.5 soul_model_uuid set from storage omegaflowey:bossfight soul_model_uuid
 
 # Add tags

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/initialize/saved.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/initialize/saved.mcfunction
@@ -8,8 +8,8 @@ stopsound @a record omega-flowey:music.soul.5
 playsound omega-flowey:soul.saved record @a ~ ~ ~ 10 1
 playsound omega-flowey:soul.transition record @a ~ ~ ~ 10 1
 
-# Flash each player/spectator's screen
-execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey, team=!spectator] at @s anchored eyes run particle minecraft:flash ^ ^ ^0.5
+# Flash each player's screen
+$execute as $(active_player_uuid) at @s anchored eyes run particle minecraft:flash ^ ^ ^0.5
 
 # Initialize other soul event models
 $execute as $(act_button_uuid) run function omegaflowey.entity:soul/soul_5/act_button/initialize/saved


### PR DESCRIPTION
# Summary

we never defined the `spectator` team. this was a long time coming.

easier to just use tags to track spectators anyway