### PR TITLE
🐛 fix `summit.no_regen` tag not being removed upon ending bossfight

### DIFF
--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/shared/stop/as_active_player/modify_health_and_tags.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/shared/stop/as_active_player/modify_health_and_tags.mcfunction
@@ -1,2 +1,3 @@
 effect give @s instant_health 1 4 true
 tag @s remove omegaflowey.player.fighting_flowey
+tag @s remove summit.no_regen


### PR DESCRIPTION
missed this