### PR TITLE
🐛 fix `dentata-snakes` bullets not dealing damage

### DIFF
--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop.mcfunction
@@ -1,7 +1,7 @@
 scoreboard players add @s omegaflowey.attack.clock.i 1
 
 execute store result storage omegaflowey:utils.damage radius float 0.0001 run scoreboard players get @s omegaflowey.attack.bullets.radius
-data merge storage omegaflowey:utils.damage { damage: 2.5 }
+data merge storage omegaflowey:utils.damage { damage: 3 }
 function omegaflowey.entity:utils/damage with storage omegaflowey:utils.damage
 
 # Check if inside arena


### PR DESCRIPTION
this was due to the fact that we now check `player.health` as an int score, and we were passing in a float damage amount. so the damage function failed

https://github.com/TheAfroOfDoom/omegaflowey-minecraft-remastered/blob/93339ab0a433ac1e66569dbfce90506a6cdb075f/datapacks/omegaflowey/data/omegaflowey.entity/function/utils/damage/as_player.mcfunction#L3-L4