### PR TITLE
💄 adjust "now playing" player head/health around center of monitor

### DIFF
--- a/datapacks/omegaflowey/data/omegaflowey.main/function/summit/room/cave/active_player_display/as_text_display.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.main/function/summit/room/cave/active_player_display/as_text_display.mcfunction
@@ -1,4 +1,4 @@
-setblock -134 43 44 air
+setblock -133 43 44 air
 
 $execute unless entity $(active_player_uuid) run \
   data modify entity @s text set value '[{ "text": "NONE", "bold": true, "color": "green" }]'
@@ -6,4 +6,4 @@ $execute unless entity $(active_player_uuid) run return 0
 
 $data modify entity @s text set value '[{ "selector": "$(active_player_uuid)", "color": "white" }]'
 
-$setblock -134 43 44 minecraft:player_wall_head[facing=north]{ profile: { id: $(active_player_uuid_intarray) } }
+$setblock -133 43 44 minecraft:player_wall_head[facing=north]{ profile: { id: $(active_player_uuid_intarray) } }

--- a/datapacks/omegaflowey/data/omegaflowey.main/function/summit/room/cave/setup/text_displays.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.main/function/summit/room/cave/setup/text_displays.mcfunction
@@ -51,7 +51,7 @@ execute as @e[ \
 ] run function gu:generate
 data modify storage omegaflowey:bossfight active_player_display_uuid set from storage gu:main out
 
-summon minecraft:text_display -132.5 43.1875 44.99 { \
+summon minecraft:text_display -134.5 43.1875 44.99 { \
   Tags: [ \
     "omega-flowey-remastered", \
     "decorative", \
@@ -72,7 +72,7 @@ summon minecraft:text_display -132.5 43.1875 44.99 { \
   } \
 }
 execute as @e[ \
-  x=-133.0, dx=2, y=42.0, dy=2, z=44.0, dz=2, \
+  x=-135.0, dx=2, y=42.0, dy=2, z=44.0, dz=2, \
   type=minecraft:text_display, \
   tag=now-playing-player-health, \
   tag=omega-flowey-remastered, \


### PR DESCRIPTION
it was off-center before. so we moved the player skull/health to center around the middle of the monitor instead of forcing the player skull to be in the center

| before | after |
|-|-|
| ![2024-10-12_15 28 49](https://github.com/user-attachments/assets/9a490504-2ba2-445c-83ae-0ab2b0b5f7d9) | ![2024-10-12_15 26 18](https://github.com/user-attachments/assets/e070308c-ab39-4f0a-a7e2-cf995bca7efd) |