### PR TITLE
♻️ replace player-selectors with macro UUIDs/volume bounds

### DIFF
--- a/datapacks/omegaflowey/data/_/function/test/attacks.mcfunction
+++ b/datapacks/omegaflowey/data/_/function/test/attacks.mcfunction
@@ -1,6 +1,9 @@
 function _:boss_fight/tag
 function _:summon
 
+function gu:generate
+data modify storage omegaflowey:bossfight active_player_uuid set from storage gu:main out
+
 data merge storage omegaflowey:dev.attack_test_suite { attacks: [ \
   { name: "bomb" }, \
   { name: "dentata-snakes" }, \

--- a/datapacks/omegaflowey/data/_/function/test/attacks/scheduled/macro.mcfunction
+++ b/datapacks/omegaflowey/data/_/function/test/attacks/scheduled/macro.mcfunction
@@ -1,1 +1,4 @@
+$function omegaflowey.utils:log { text_component: \
+  '[ { "text": "Running: attack/$(name)" } ]' \
+}
 $execute at @p[tag=omegaflowey.player.fighting_flowey] run function _:attack/$(name)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/shared/phase/soul/static/as_root.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/shared/phase/soul/static/as_root.mcfunction
@@ -1,4 +1,6 @@
 # Play static sound
-playsound omega-flowey:boss-fight.static ambient @a ~ ~ ~ 10
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:boss-fight.static ambient @s ~ ~ ~ 10' \
+}
 
 function animated_java:omegaflowey_tv_screen/variants/static/apply

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/shared/stop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/shared/stop.mcfunction
@@ -5,10 +5,10 @@ execute as @e[ \
   tag=omega-flowey-remastered \
 ] run function omegaflowey.entity:directorial/boss_fight/shared/stop/as_root
 
-# TAG_SUMMIT_HARDCODED_GLOBAL_VOLUME
-execute as @a[x=-186, dx=91, y=12, dy=93, z=12, dz=95, tag=omegaflowey.player.room.spectator_box] run \
-  function omegaflowey.entity:directorial/boss_fight/shared/stop/as_spectator
-
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'execute unless entity @s[tag=omegaflowey.player.fighting_flowey] run \
+    function omegaflowey.entity:directorial/boss_fight/shared/stop/as_spectator' \
+}
 $execute as $(active_player_uuid) run function omegaflowey.entity:directorial/boss_fight/shared/stop/as_active_player
 
 data modify storage omegaflowey:bossfight active_player_uuid set value "0"

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/attack/initialize/0.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/attack/initialize/0.mcfunction
@@ -3,7 +3,9 @@
 scoreboard players set @s omegaflowey.boss-fight.attack.clock.total 463
 
 # Play music
-playsound omega-flowey:music.phase.0 record @a ~ ~ ~ 10 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:music.phase.0 record @s ~ ~ ~ 10 1' \
+}
 
 ## Add tags
 # Use logic to decrease chance of repeating attacks during `attack/random`

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/attack/initialize/1.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/attack/initialize/1.mcfunction
@@ -3,7 +3,9 @@
 scoreboard players set @s omegaflowey.boss-fight.attack.clock.total 414
 
 # Play music
-playsound omega-flowey:music.phase.1 record @a ~ ~ ~ 10 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:music.phase.1 record @s ~ ~ ~ 10 1' \
+}
 
 ## Add tags
 # Use logic to decrease chance of repeating attacks during `attack/random`

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/warn/initialize/after_delay.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/summit/phase/warn/initialize/after_delay.mcfunction
@@ -1,5 +1,7 @@
 # Play WARNING sound
-$execute at $(bossfight_tvscreen_uuid) run playsound omega-flowey:boss-fight.alarm ambient @a ~ ~ ~ 10 1
+$execute at $(bossfight_tvscreen_uuid) run function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:boss-fight.alarm ambient @s ~ ~ ~ 10 1' \
+}
 
 # Set tv screen to WARNING variant
 $execute as $(bossfight_tvscreen_uuid) run function omegaflowey.entity:hostile/omega-flowey/animate/warning/tv_screen

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/start_falling.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/start_falling.mcfunction
@@ -1,2 +1,3 @@
-stopsound @a hostile omega-flowey:attack.bomb.fall
-playsound omega-flowey:attack.bomb.fall hostile @a ~ ~ ~ 5 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'function omegaflowey.entity:hostile/omega-flowey/attack/bomb/bullet/loop/start_falling/as_player' \
+}

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/start_falling/as_player.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/start_falling/as_player.mcfunction
@@ -1,0 +1,2 @@
+stopsound @s hostile omega-flowey:attack.bomb.fall
+playsound omega-flowey:attack.bomb.fall hostile @s ~ ~ ~ 5 1

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling.mcfunction
@@ -5,8 +5,9 @@ function omegaflowey.entity:directorial/boss_fight/summit/origin/at/y { \
 
 # Play animation if we just stopped falling
 execute unless entity @s[tag=is_done_falling] run function animated_java:omegaflowey_bomb/animations/omegaflowey_explode/play
-execute unless entity @s[tag=is_done_falling] run stopsound @a hostile omega-flowey:attack.bomb.explode
-execute unless entity @s[tag=is_done_falling] run playsound omega-flowey:attack.bomb.explode hostile @a ~ ~ ~ 5 1
+execute unless entity @s[tag=is_done_falling] run function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'function omegaflowey.entity:hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling/as_player_once' \
+}
 
 # Add tags
 tag @s add is_done_falling

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling/as_player_once.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling/as_player_once.mcfunction
@@ -1,0 +1,2 @@
+stopsound @s hostile omega-flowey:attack.bomb.explode
+playsound omega-flowey:attack.bomb.explode hostile @s ~ ~ ~ 5 1

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/initialize/head.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/initialize/head.mcfunction
@@ -1,6 +1,6 @@
-# Play summon sounds
-playsound omega-flowey:attack.dentata-snakes.spawn hostile @a ~ ~ ~ 5 1
-playsound omega-flowey:attack.dentata-snakes.summon hostile @a ~ ~ ~ 5 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'function omegaflowey.entity:hostile/omega-flowey/attack/dentata-snakes/bullet/initialize/head/as_player' \
+}
 
 # Add tags
 tag @s add attack-bullet-head

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/initialize/head/as_player.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/initialize/head/as_player.mcfunction
@@ -1,0 +1,3 @@
+# Play summon sounds
+playsound omega-flowey:attack.dentata-snakes.spawn hostile @s ~ ~ ~ 5 1
+playsound omega-flowey:attack.dentata-snakes.summon hostile @s ~ ~ ~ 5 1

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/after_bounce_as_bullet_head.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/after_bounce_as_bullet_head.mcfunction
@@ -1,4 +1,6 @@
 # If we bounced, play bounce sound
 # Only the bullet-head makes bounce sounds/shakes the player's screen (see `maybe_bounce.mcfunction`)
-playsound omega-flowey:attack.dentata-snakes.bounce hostile @a ~ ~ ~ 5 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:attack.dentata-snakes.bounce hostile @s ~ ~ ~ 5 1' \
+}
 # execute as @a unless entity @s[tag=!omegaflowey.player.fighting_flowey,team=!dead,tag=!omegaflowey.player.room.spectator_box] at @s run function omegaflowey.entity:utils/shake_screen

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/bullet/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/bullet/initialize.mcfunction
@@ -6,8 +6,9 @@ data merge entity @s {CustomName:"\"Finger-Guns Bullet\""}
 scoreboard players operation @s omegaflowey.attack.speed.z = #omegaflowey.attack.finger-guns omegaflowey.attack.speed.z
 
 # Play bullet shoot sound
-stopsound @a hostile omega-flowey:attack.finger-guns.shoot
-playsound omega-flowey:attack.finger-guns.shoot hostile @a ~ ~ ~ 5 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'function omegaflowey.entity:hostile/omega-flowey/attack/finger-guns/bullet/initialize/as_player' \
+}
 
 # Add tags
 tag @s add finger-guns

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/bullet/initialize/as_player.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/bullet/initialize/as_player.mcfunction
@@ -1,0 +1,2 @@
+stopsound @s hostile omega-flowey:attack.finger-guns.shoot
+playsound omega-flowey:attack.finger-guns.shoot hostile @s ~ ~ ~ 5 1

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/indicator/loop/laser/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/indicator/loop/laser/initialize.mcfunction
@@ -3,7 +3,9 @@ function omegaflowey.entity:hostile/omega-flowey/attack/shared/initialize
 data modify entity @s CustomName set value '"Finger-Guns Laser"'
 
 # Play laser sound (blink) once
-playsound omega-flowey:attack.finger-guns.laser hostile @a ~ ~ ~ 5 1 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:attack.finger-guns.laser hostile @s ~ ~ ~ 5 1 1' \
+}
 
 # Add tags
 tag @s add finger-guns

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop.mcfunction
@@ -8,7 +8,9 @@ execute if score @s omegaflowey.attack.clock.i matches ..-1 run return 0
 # Summon an indicator at a random player every `omegaflowey.attack.executor.rate` ticks
 scoreboard players operation @s omegaflowey.math.0 = @s omegaflowey.attack.clock.i
 scoreboard players operation @s omegaflowey.math.0 %= @s omegaflowey.attack.executor.rate
-execute if score @s omegaflowey.math.0 matches 0 run function omegaflowey.entity:hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator
+execute if score @s omegaflowey.math.0 matches 0 run \
+  function omegaflowey.entity:hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator \
+    with storage omegaflowey:bossfight
 
 # Terminate
 execute if score @s omegaflowey.attack.clock.i = @s omegaflowey.attack.executor.clock.length run \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
@@ -5,7 +5,7 @@
 execute if score @s omegaflowey.attack.clock.i matches 0 run scoreboard players add #omegaflowey.attack.friendliness-pellets omegaflowey.attack.indicator.clock.delay 6
 
 # Summon indicator
-execute at @r[tag=omegaflowey.player.fighting_flowey] run function omegaflowey.entity:directorial/boss_fight/summit/origin/at/y { \
+$execute at $(active_player_uuid) run function omegaflowey.entity:directorial/boss_fight/summit/origin/at/y { \
   command: "execute positioned ~ ~-4.0 ~ run function omegaflowey.entity:hostile/omega-flowey/attack/friendliness-pellets/indicator/summon" \
 }
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/indicator/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/indicator/loop.mcfunction
@@ -8,7 +8,10 @@ execute if score @s omegaflowey.attack.clock.i = @s omegaflowey.attack.indicator
   function omegaflowey.entity:hostile/omega-flowey/attack/friendliness-pellets/indicator/loop/finished_blinking with entity @s data
 
 # Play blinking sound before we summon bullets
-execute if score @s omegaflowey.attack.clock.i matches ..-1 run playsound omega-flowey:attack.friendliness-pellets.blinking hostile @a ~ ~ ~ 3 1 1
+execute if score @s omegaflowey.attack.clock.i matches ..-1 run \
+  function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+    'playsound omega-flowey:attack.friendliness-pellets.blinking hostile @s ~ ~ ~ 3 1 1' \
+  }
 
 # Ignore bullet summoning logic while `omegaflowey.attack.clock.i` is negative
 execute if score @s omegaflowey.attack.clock.i matches ..-1 run return 0

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/indicator/terminate.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/indicator/terminate.mcfunction
@@ -11,6 +11,8 @@ $tag $(corresponding_bullet_8_uuid) remove stationary
 $tag $(corresponding_bullet_9_uuid) remove stationary
 
 # Play activate sound
-playsound omega-flowey:attack.friendliness-pellets.activate hostile @a ~ ~ ~ 3 1 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:attack.friendliness-pellets.activate hostile @s ~ ~ ~ 3 1 1' \
+}
 
 kill @s

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/bullet/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/bullet/initialize.mcfunction
@@ -7,8 +7,9 @@ scoreboard players operation @s omegaflowey.attack.speed.z = #omegaflowey.attack
 
 # Play bullet summon sound
 # This also stops any already-playing summon sounds to accurately match what Undertale's homing-vines attack sounds like
-stopsound @a hostile omega-flowey:attack.homing-vines.summon
-playsound omega-flowey:attack.homing-vines.summon hostile @a ~ ~ ~ 5 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'function omegaflowey.entity:hostile/omega-flowey/attack/homing-vines/bullet/initialize/as_player' \
+}
 
 # Add tags
 tag @s add homing-vines

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/bullet/initialize/as_player.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/bullet/initialize/as_player.mcfunction
@@ -1,0 +1,2 @@
+stopsound @s hostile omega-flowey:attack.homing-vines.summon
+playsound omega-flowey:attack.homing-vines.summon hostile @s ~ ~ ~ 5 1

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/executor/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/executor/loop.mcfunction
@@ -8,7 +8,9 @@ execute if score @s omegaflowey.attack.clock.i matches ..-1 run return 0
 # Summon an indicator at a random player every `omegaflowey.attack.executor.rate` ticks
 scoreboard players operation @s omegaflowey.math.0 = @s omegaflowey.attack.clock.i
 scoreboard players operation @s omegaflowey.math.0 %= @s omegaflowey.attack.executor.rate
-execute if score @s omegaflowey.math.0 matches 0 run function omegaflowey.entity:hostile/omega-flowey/attack/homing-vines/executor/loop/summon_indicator
+execute if score @s omegaflowey.math.0 matches 0 run \
+  function omegaflowey.entity:hostile/omega-flowey/attack/homing-vines/executor/loop/summon_indicator \
+    with storage omegaflowey:bossfight
 
 # Terminate
 execute if score @s omegaflowey.attack.clock.i = @s omegaflowey.attack.executor.clock.length run \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/executor/loop/summon_indicator.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/executor/loop/summon_indicator.mcfunction
@@ -1,2 +1,2 @@
 # Summon and initialize indicator
-execute at @r[tag=omegaflowey.player.fighting_flowey] summon minecraft:marker run function omegaflowey.entity:hostile/omega-flowey/attack/homing-vines/indicator/initialize
+$execute at $(active_player_uuid) summon minecraft:marker run function omegaflowey.entity:hostile/omega-flowey/attack/homing-vines/indicator/initialize

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/loop/visualize_blinking_lane.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/loop/visualize_blinking_lane.mcfunction
@@ -2,4 +2,6 @@
 $execute as $(blinking_lane_uuid) on passengers if entity @s[tag=aj.omegaflowey_homing_vine_blinking_lane.bone.root] run data modify entity @s view_range set value 1
 
 # Play blinking sound once
-playsound omega-flowey:attack.homing-vines.blinking hostile @a ~ ~ ~ 3 1 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:attack.homing-vines.blinking hostile @s ~ ~ ~ 3 1 1' \
+}

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-lower/executor/initialize/effects.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-lower/executor/initialize/effects.mcfunction
@@ -4,4 +4,6 @@
 # TODO(36): maybe `particle minecraft:flash`?
 particle minecraft:explosion ~ ~ ~ 0 0 0 10 1 force
 
-playsound omega-flowey:attack.x-bullets.start hostile @a ~ ~ ~ 3 1 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:attack.x-bullets.start hostile @s ~ ~ ~ 3 1 1' \
+}

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-upper/executor/initialize/effects.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-upper/executor/initialize/effects.mcfunction
@@ -4,4 +4,6 @@
 # TODO(36): maybe `particle minecraft:flash`?
 particle minecraft:explosion ~ ~ ~ 0 0 0 10 1 force
 
-playsound omega-flowey:attack.x-bullets.start hostile @a ~ ~ ~ 3 1 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:attack.x-bullets.start hostile @s ~ ~ ~ 3 1 1' \
+}

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/player/room/spectator_box/exit.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/player/room/spectator_box/exit.mcfunction
@@ -1,1 +1,2 @@
 tag @s remove omegaflowey.player.room.spectator_box
+function omegaflowey.entity:directorial/boss_fight/shared/stop/as_spectator

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/shared/run_as_active_player_or_spectator.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/shared/run_as_active_player_or_spectator.mcfunction
@@ -1,0 +1,5 @@
+# NOTE: TAG_SUMMIT_HARDCODED_GLOBAL_VOLUME
+$execute \
+  as @a[x=-186, dx=91, y=12, dy=93, z=12, dz=95] \
+  unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] \
+  run $(command)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/initialize/saved.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/initialize/saved.mcfunction
@@ -1,12 +1,9 @@
 # Update state flag
 scoreboard players set #omegaflowey.soul.5.saved omegaflowey.soul.flag 1
 
-# Stop event music
-stopsound @a record omega-flowey:music.soul.5
-
-# Play saved music + sound effect
-playsound omega-flowey:soul.saved record @a ~ ~ ~ 10 1
-playsound omega-flowey:soul.transition record @a ~ ~ ~ 10 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'function omegaflowey.entity:soul/soul_5/executor/initialize/saved/as_player' \
+}
 
 # Flash each player's screen
 $execute as $(active_player_uuid) at @s anchored eyes run particle minecraft:flash ^ ^ ^0.5

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/initialize/saved/as_player.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/initialize/saved/as_player.mcfunction
@@ -1,0 +1,6 @@
+# Stop event music
+stopsound @s record omega-flowey:music.soul.5
+
+# Play saved music + sound effect
+playsound omega-flowey:soul.saved record @s ~ ~ ~ 10 1
+playsound omega-flowey:soul.transition record @s ~ ~ ~ 10 1

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/loop.mcfunction
@@ -1,5 +1,5 @@
 # Loop logic for players
-execute as @a[tag=omegaflowey.player.fighting_flowey] run function omegaflowey.entity:soul/soul_5/executor/loop/as_player
+$execute as $(active_player_uuid) run function omegaflowey.entity:soul/soul_5/executor/loop/as_player
 
 scoreboard players add @s omegaflowey.soul.clock.i 1
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/play_music.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/play_music.mcfunction
@@ -1,1 +1,3 @@
-playsound omega-flowey:music.soul.5 record @a ~ ~ ~ 10 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:music.soul.5 record @s ~ ~ ~ 10 1' \
+}

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/terminate.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/terminate.mcfunction
@@ -7,8 +7,9 @@ execute as @e[ \
   tag=omega-flowey-remastered \
 ] run function omegaflowey.entity:soul/soul_5/executor/terminate/as_root
 
-stopsound @a record omega-flowey:music.soul.5
-stopsound @a record omega-flowey:soul.saved
-effect clear @a[tag=omegaflowey.player.fighting_flowey] minecraft:resistance
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'function omegaflowey.entity:soul/soul_5/executor/terminate/as_player' \
+}
+$effect clear $(active_player_uuid) minecraft:resistance
 
 kill @s

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/terminate/as_player.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/terminate/as_player.mcfunction
@@ -1,0 +1,2 @@
+stopsound @s record omega-flowey:music.soul.5
+stopsound @s record omega-flowey:soul.saved

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/healer/heal.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/healer/heal.mcfunction
@@ -1,2 +1,2 @@
-execute as @p[tag=omegaflowey.player.fighting_flowey] at @s run function omegaflowey.entity:soul/soul_5/healer/heal/as_player
+$execute as $(active_player_uuid) at @s run function omegaflowey.entity:soul/soul_5/healer/heal/as_player
 function omegaflowey.entity:soul/soul_5/healer/terminate

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/healer/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/healer/loop.mcfunction
@@ -1,7 +1,8 @@
 # Check if any of this bandaid's locator's hitboxes intersect with a player
 scoreboard players set #omegaflowey.soul.5.flower_touched_player omegaflowey.soul.flag 0
 function animated_java:omegaflowey_soul_5_flower/as_own_locator_entities { command: 'function omegaflowey.entity:soul/soul_5/healer/loop/as_locator with entity @s data' }
-execute if score #omegaflowey.soul.5.flower_touched_player omegaflowey.soul.flag matches 1 run function omegaflowey.entity:soul/soul_5/healer/heal
+execute if score #omegaflowey.soul.5.flower_touched_player omegaflowey.soul.flag matches 1 run \
+  function omegaflowey.entity:soul/soul_5/healer/heal with storage omegaflowey:bossfight
 execute if score #omegaflowey.soul.5.flower_touched_player omegaflowey.soul.flag matches 1 run return 0
 
 # Move forward

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/loop.mcfunction
@@ -6,7 +6,7 @@ execute if score @s omegaflowey.soul.clock.i matches ..-1 run return 0
 
 # state-loop is: idle -> aiming -> shooting -> aiming -> shooting -> aiming -> ...
 execute if entity @s[tag=soul_5.idle] run function omegaflowey.entity:soul/soul_5/indicator/loop/idle
-execute if entity @s[tag=soul_5.aiming] run function omegaflowey.entity:soul/soul_5/indicator/loop/aiming
+execute if entity @s[tag=soul_5.aiming] run function omegaflowey.entity:soul/soul_5/indicator/loop/aiming with storage omegaflowey:bossfight
 execute if entity @s[tag=soul_5.shooting] run function omegaflowey.entity:soul/soul_5/indicator/loop/shooting
 
 # Shaking animation

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/loop/aiming.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/loop/aiming.mcfunction
@@ -5,4 +5,5 @@ execute if score @s omegaflowey.soul.clock.i matches ..-1 run return 0
 
 scoreboard players operation @s omegaflowey.math.0 = @s omegaflowey.soul.clock.i
 scoreboard players operation @s omegaflowey.math.0 %= #omegaflowey.const.4 omegaflowey.math.const
-execute if score @s omegaflowey.math.0 matches 0 at @r[tag=omegaflowey.player.fighting_flowey] run function omegaflowey.entity:soul/soul_5/indicator/loop/aiming/next_crosshair
+$execute if score @s omegaflowey.math.0 matches 0 at $(active_player_uuid) run \
+  function omegaflowey.entity:soul/soul_5/indicator/loop/aiming/next_crosshair

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/tick.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/tick.mcfunction
@@ -1,6 +1,6 @@
 execute if entity @s[tag=act-button] run function omegaflowey.entity:soul/soul_5/act_button/loop
 execute if entity @s[tag=soul-bullet] run function omegaflowey.entity:soul/soul_5/bullet/loop
-execute if entity @s[tag=soul-executor] run function omegaflowey.entity:soul/soul_5/executor/loop
+execute if entity @s[tag=soul-executor] run function omegaflowey.entity:soul/soul_5/executor/loop with storage omegaflowey:bossfight
 execute if entity @s[tag=soul-healer] run function omegaflowey.entity:soul/soul_5/healer/loop
 execute if entity @s[tag=soul-indicator] run function omegaflowey.entity:soul/soul_5/indicator/loop
 execute if entity @s[tag=soul-locator] run function omegaflowey.entity:soul/soul_5/locator/loop

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/utils/damage/as_player.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/utils/damage/as_player.mcfunction
@@ -25,11 +25,16 @@ schedule function omegaflowey.main:summit/room/cave/active_player_health_display
 schedule function omegaflowey.entity:utils/damage/reset_immunity_flag 10t replace
 
 # Show custom death message
-execute if score #omegaflowey.bossfight.show_custom_death_message omegaflowey.global.flag matches 1 run tellraw @a [ \
-  { "selector": "@s"}, \
-  " was slain by ", \
-  { "text": "Omega Flowey", "color": "green" } \
-]
+# TAG_SUMMIT_HARDCODED_GLOBAL_VOLUME
+execute if score #omegaflowey.bossfight.show_custom_death_message omegaflowey.global.flag matches 1 run \
+  tellraw @a[ \
+    x=-186, dx=91, y=12, dy=93, z=12, dz=95, \
+    tag=omegaflowey.player \
+  ] [ \
+    { "selector": "@s"}, \
+    " was slain by ", \
+    { "text": "Omega Flowey", "color": "green" } \
+  ]
 
 # Re-enable `showDeathMessages` if it was enabled previously
 execute if score #omegaflowey.bossfight.show_custom_death_message omegaflowey.global.flag matches 1 \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/utils/face_closest_player.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/utils/face_closest_player.mcfunction
@@ -1,5 +1,10 @@
-execute store result storage omegaflowey:entity.utils.face_closest_player x float 0.01 run scoreboard players get @s omegaflowey.attack.position.x
-execute store result storage omegaflowey:entity.utils.face_closest_player y float 0.01 run scoreboard players get @s omegaflowey.attack.position.y
-execute store result storage omegaflowey:entity.utils.face_closest_player z float 0.01 run scoreboard players get @s omegaflowey.attack.position.z
+execute store result storage omegaflowey:entity.utils.face_closest_player x float 0.01 run \
+  scoreboard players get @s omegaflowey.attack.position.x
+execute store result storage omegaflowey:entity.utils.face_closest_player y float 0.01 run \
+  scoreboard players get @s omegaflowey.attack.position.y
+execute store result storage omegaflowey:entity.utils.face_closest_player z float 0.01 run \
+  scoreboard players get @s omegaflowey.attack.position.z
+data modify storage omegaflowey:entity.utils.face_closest_player active_player_uuid set from \
+  storage omegaflowey:bossfight active_player_uuid
 
 function omegaflowey.entity:utils/face_closest_player_macro with storage omegaflowey:entity.utils.face_closest_player

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/utils/face_closest_player_macro.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/utils/face_closest_player_macro.mcfunction
@@ -1,1 +1,1 @@
-$execute positioned $(x) $(y) $(z) run teleport @s ~ ~ ~ facing entity @p[tag=omegaflowey.player.fighting_flowey] feet
+$execute positioned $(x) $(y) $(z) run teleport @s ~ ~ ~ facing entity $(active_player_uuid) feet

--- a/datapacks/omegaflowey/data/omegaflowey.main/function/setup.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.main/function/setup.mcfunction
@@ -7,6 +7,6 @@ function omegaflowey.entity:setup
 
 # don't run room setup if there are no players on, as this duplicates entities due to them
 # not being loaded
-execute if entity @a run function omegaflowey.main:summit/room/setup
+execute if entity @a[limit=1] run function omegaflowey.main:summit/room/setup
 
 function omegaflowey.utils:log { text_component: '[ { "text": "Datapack initialized", "color": "aqua" } ]'}


### PR DESCRIPTION
# Summary

most of our player selectors (esp `@a`s weren't bounded by anything, so stuff like sounds were playing to every player in the world regardless of location).

these are now bounded to their specific contexts (e.g. bossfight music/sounds only playing to the active player + spectators)

---

## Supplemental changes

- [`c7e3fff` (#225)](https://github.com/TheAfroOfDoom/omegaflowey-minecraft-remastered/pull/225/commits/c7e3ffff12e23577aa57c24bdb21817261ff1b69): 🧑‍💻 store `active_player_uuid` to storage when running attack test suite
- [`6da497e` (#225)](https://github.com/TheAfroOfDoom/omegaflowey-minecraft-remastered/pull/225/commits/6da497eda3d97debc7b536a8d7ba2321867d2d4d): 🚸 stop bossfight music/sounds when player leaves spectator box