### PR TITLE
🔧 prune unused AJ exports from build

### DIFF
--- a/package-scripts/build.js
+++ b/package-scripts/build.js
@@ -146,6 +146,28 @@ const getSummitResourcepackPaths = () => {
     'soul_0_sword',
     'venus_fly_trap',
   ]);
+  const pruneAnimatedJavaDisplayItem = async ({ compiledPath }) => {
+    const displayItemPath = `${compiledPath}/assets/minecraft/models/item/pink_dye.json`;
+    const displayItemJson = await readJson(displayItemPath);
+
+    const filteredOverrides = displayItemJson.overrides.filter((override) => {
+      if (!override.model.startsWith('animated_java:item/')) {
+        return true;
+      }
+
+      const modelName = override.model
+        .replace('animated_java:item/', '')
+        .split('/')[0];
+      return !animatedJavaExportsToPrune.includes(modelName);
+    });
+
+    displayItemJson.overrides = filteredOverrides;
+
+    displayItemJson.animated_java = undefined;
+
+    await writeJson(displayItemPath, displayItemJson, { spaces: 2 });
+  };
+  postProcessors.push(pruneAnimatedJavaDisplayItem);
 
   const modelPaths = prefixPaths('models/entity/decorative/', [
     'housefly.json',

--- a/package-scripts/build.js
+++ b/package-scripts/build.js
@@ -138,6 +138,15 @@ const getSummitResourcepackPaths = () => {
   // Not `minecraft/sounds.json` since we just use that to disable ambient sounds
   const minecraftPaths = prefixPaths('minecraft/', ['atlases', 'models']);
 
+  const animatedJavaExportsToPrune = prefixPaths('omegaflowey_', [
+    'housefly',
+    'petal_pipe_circle',
+    'petal_pipe_middle',
+    'soul_0_bandaid',
+    'soul_0_sword',
+    'venus_fly_trap',
+  ]);
+
   const modelPaths = prefixPaths('models/entity/decorative/', [
     'housefly.json',
     'picture',
@@ -299,6 +308,16 @@ const getSummitResourcepackPaths = () => {
     ...minecraftPaths,
     ...omegaFloweyPaths,
   ]);
+
+  const pruneAnimatedJavaResourcepackExports = async ({ compiledPath }) => {
+    const prunePromises = [];
+    for (const dir of animatedJavaExportsToPrune) {
+      const compiledPruneDir = `${compiledPath}/assets/animated_java/models/item/${dir}`;
+      prunePromises.push(rimraf(compiledPruneDir));
+    }
+    await Promise.all(prunePromises);
+  };
+  postProcessors.push(pruneAnimatedJavaResourcepackExports);
 
   const resourcepackPaths = prefixPaths('resourcepack/', [
     'pack.mcmeta',


### PR DESCRIPTION
we dont use these files in summit, so the summit RP/DPs don't need them