### PR TITLE
⚔️ migrate attacks back to vanilla world

### DIFF
--- a/datapacks/omegaflowey/data/_/function/README.md
+++ b/datapacks/omegaflowey/data/_/function/README.md
@@ -4,6 +4,7 @@ This directory contains convenience functions for developers for quicker calls t
 
 ## Functions
 
+- `active_player`: sets the executor as the active player
 - `attack`: runs the pre-defined attack's `start` function
   - `attack/random/N`: randomly starts an attack from the `boss_fight`'s attack phase `N` (e.g. `N = 0`)
 - `boss_fight`: starts the vanilla boss fight

--- a/datapacks/omegaflowey/data/_/function/active_player.mcfunction
+++ b/datapacks/omegaflowey/data/_/function/active_player.mcfunction
@@ -1,0 +1,2 @@
+function gu:generate
+data modify storage omegaflowey:bossfight active_player_uuid set from storage gu:main out

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop.mcfunction
@@ -19,7 +19,7 @@ execute if score @s omegaflowey.attack.clock.i matches 20.. run teleport @s ~ ~-
 
 # Check if below the floor
 scoreboard players set @s omegaflowey.math.0 0
-function omegaflowey.entity:directorial/boss_fight/summit/origin/at/position { \
+function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/position { \
   command: "execute positioned ~100.0 ~-4.0 ~87.5 if entity @s[dx=-200,dy=-20,dz=-200] run \
     scoreboard players set @s omegaflowey.math.0 1\
   " \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling.mcfunction
@@ -1,5 +1,5 @@
 # Keep consistent y-pos
-function omegaflowey.entity:directorial/boss_fight/summit/origin/at/y { \
+function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/y { \
   command: "teleport @s ~ ~-4.0 ~" \
 }
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/presummon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/presummon.mcfunction
@@ -1,11 +1,11 @@
 # Randomize x/z-position to summon bullet
 execute store result score @s omegaflowey.attack.position.x run random value -150..150
 scoreboard players operation @s omegaflowey.attack.position.x *= #omegaflowey.const.10 omegaflowey.math.const
-scoreboard players operation @s omegaflowey.attack.position.x += #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.attack.position.x += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 
 execute store result score @s omegaflowey.attack.position.z run random value -315..-85
 scoreboard players operation @s omegaflowey.attack.position.z *= #omegaflowey.const.10 omegaflowey.math.const
-scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.summit.origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 
 # Store position
 execute store result storage omegaflowey:attack.bomb x double 0.01 run scoreboard players get @s omegaflowey.attack.position.x

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/presummon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/presummon.mcfunction
@@ -3,7 +3,7 @@ execute store result score @s omegaflowey.attack.position.x run random value -15
 scoreboard players operation @s omegaflowey.attack.position.x *= #omegaflowey.const.10 omegaflowey.math.const
 scoreboard players operation @s omegaflowey.attack.position.x += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 
-execute store result score @s omegaflowey.attack.position.z run random value -315..-85
+execute store result score @s omegaflowey.attack.position.z run random value 85..315
 scoreboard players operation @s omegaflowey.attack.position.z *= #omegaflowey.const.10 omegaflowey.math.const
 scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/summon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/summon.mcfunction
@@ -1,5 +1,5 @@
 # Summon, initialize, and animate bullet (scale-in from 0)
-$function omegaflowey.entity:directorial/boss_fight/summit/origin/at/y { \
+$function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/y { \
   command: "execute positioned $(x) ~23.0 $(z) run function animated_java:omegaflowey_bomb/summon { \
     args: { animation: 'omegaflowey_summon', start_animation: true } \
   }" \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop.mcfunction
@@ -7,7 +7,7 @@ function omegaflowey.entity:utils/damage with storage omegaflowey:utils.damage
 # Check if inside arena
 scoreboard players set @s omegaflowey.math.0 0
 function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/position { \
-  command: "execute positioned ~12.5 ~-17.0 ~-11.0 if entity @s[dx=-25,dy=40,dz=-19] run \
+  command: "execute positioned ~12.5 ~-17.0 ~11.0 if entity @s[dx=-25,dy=40,dz=19] run \
     scoreboard players set @s omegaflowey.math.0 1\
   " \
 }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop.mcfunction
@@ -6,7 +6,7 @@ function omegaflowey.entity:utils/damage with storage omegaflowey:utils.damage
 
 # Check if inside arena
 scoreboard players set @s omegaflowey.math.0 0
-function omegaflowey.entity:directorial/boss_fight/summit/origin/at/position { \
+function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/position { \
   command: "execute positioned ~12.5 ~-17.0 ~-11.0 if entity @s[dx=-25,dy=40,dz=-19] run \
     scoreboard players set @s omegaflowey.math.0 1\
   " \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/maybe_bounce.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/maybe_bounce.mcfunction
@@ -1,7 +1,7 @@
 # Check if escaped arena past z-bound towarsd flowey
 scoreboard players set @s omegaflowey.math.0 0
 function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/position { \
-  command: "execute positioned ~1000.0 ~-7.0 ~-11.0 if entity @s[dx=-2000,dy=10,dz=1000] run \
+  command: "execute positioned ~1000.0 ~-7.0 ~11.0 if entity @s[dx=-2000,dy=10,dz=-1000] run \
     scoreboard players set @s omegaflowey.math.0 1" \
 }
 
@@ -18,12 +18,12 @@ scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.van
 execute store result storage omegaflowey:attack.dentata-snakes.bounce x_positive_x float 0.01 run scoreboard players get @s omegaflowey.math.0
 data modify storage omegaflowey:attack.dentata-snakes.bounce x_positive_dx set value -50
 
-scoreboard players set @s omegaflowey.math.0 -3000
+scoreboard players set @s omegaflowey.math.0 1100
 scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 execute store result storage omegaflowey:attack.dentata-snakes.bounce z_negative_z float 0.01 run scoreboard players get @s omegaflowey.math.0
 data modify storage omegaflowey:attack.dentata-snakes.bounce z_negative_dz set value 25
 
-scoreboard players set @s omegaflowey.math.0 -1100
+scoreboard players set @s omegaflowey.math.0 3000
 scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 execute store result storage omegaflowey:attack.dentata-snakes.bounce z_positive_z float 0.01 run scoreboard players get @s omegaflowey.math.0
 data modify storage omegaflowey:attack.dentata-snakes.bounce z_positive_dz set value -25

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/maybe_bounce.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/maybe_bounce.mcfunction
@@ -1,6 +1,6 @@
 # Check if escaped arena past z-bound towarsd flowey
 scoreboard players set @s omegaflowey.math.0 0
-function omegaflowey.entity:directorial/boss_fight/summit/origin/at/position { \
+function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/position { \
   command: "execute positioned ~1000.0 ~-7.0 ~-11.0 if entity @s[dx=-2000,dy=10,dz=1000] run \
     scoreboard players set @s omegaflowey.math.0 1" \
 }
@@ -9,32 +9,35 @@ function omegaflowey.entity:directorial/boss_fight/summit/origin/at/position { \
 execute if score @s omegaflowey.math.0 matches 1 if entity @s[tag=can-escape-arena] run return 0
 
 scoreboard players set @s omegaflowey.math.0 -1250
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 execute store result storage omegaflowey:attack.dentata-snakes.bounce x_negative_x float 0.01 run scoreboard players get @s omegaflowey.math.0
 data modify storage omegaflowey:attack.dentata-snakes.bounce x_negative_dx set value 50
 
 scoreboard players set @s omegaflowey.math.0 1250
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 execute store result storage omegaflowey:attack.dentata-snakes.bounce x_positive_x float 0.01 run scoreboard players get @s omegaflowey.math.0
 data modify storage omegaflowey:attack.dentata-snakes.bounce x_positive_dx set value -50
 
 scoreboard players set @s omegaflowey.math.0 -3000
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 execute store result storage omegaflowey:attack.dentata-snakes.bounce z_negative_z float 0.01 run scoreboard players get @s omegaflowey.math.0
 data modify storage omegaflowey:attack.dentata-snakes.bounce z_negative_dz set value 25
 
 scoreboard players set @s omegaflowey.math.0 -1100
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 execute store result storage omegaflowey:attack.dentata-snakes.bounce z_positive_z float 0.01 run scoreboard players get @s omegaflowey.math.0
 data modify storage omegaflowey:attack.dentata-snakes.bounce z_positive_dz set value -25
 
 scoreboard players set @s omegaflowey.math.0 -700
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.y omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.y omegaflowey.global.flag
 execute store result storage omegaflowey:attack.dentata-snakes.bounce y float 0.01 run scoreboard players get @s omegaflowey.math.0
 data modify storage omegaflowey:attack.dentata-snakes.bounce dy set value 10
 
-data modify storage omegaflowey:attack.dentata-snakes.bounce command_after_bouncing set value 'execute if entity @s[tag=attack-bullet-head] at @s run function omegaflowey.entity:hostile/omega-flowey/attack/dentata-snakes/bullet/loop/after_bounce_as_bullet_head'
+data modify storage omegaflowey:attack.dentata-snakes.bounce command_after_bouncing set value '\
+  execute if entity @s[tag=attack-bullet-head] at @s run \
+    function omegaflowey.entity:hostile/omega-flowey/attack/dentata-snakes/bullet/loop/after_bounce_as_bullet_head\
+'
 
-function omegaflowey.entity:directorial/boss_fight/summit/origin/at/position { \
+function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/position { \
   command: "function omegaflowey.entity:utils/bounce with storage omegaflowey:attack.dentata-snakes.bounce" \
 }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/initialize.mcfunction
@@ -15,10 +15,10 @@ scoreboard players operation @s omegaflowey.attack.bullets.total = #omegaflowey.
 # Randomize position to summon bullet at
 execute store result score @s omegaflowey.attack.bullets.position.x run random value -800..800
 scoreboard players operation @s omegaflowey.attack.bullets.position.x += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
-scoreboard players set @s omegaflowey.attack.bullets.position.z -750
+scoreboard players set @s omegaflowey.attack.bullets.position.z 750
 scoreboard players operation @s omegaflowey.attack.bullets.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 
 # Randomize initial yaw of bullets
 execute store result score @s omegaflowey.math.0 run random value 0..1
-execute if score @s omegaflowey.math.0 matches 0 run data merge entity @s { Rotation:[135.0f, 0f] }
-execute if score @s omegaflowey.math.0 matches 1 run data merge entity @s { Rotation:[-135.0f, 0f] }
+execute if score @s omegaflowey.math.0 matches 0 run data merge entity @s { Rotation:[45.0f, 0f] }
+execute if score @s omegaflowey.math.0 matches 1 run data merge entity @s { Rotation:[-45.0f, 0f] }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/initialize.mcfunction
@@ -14,9 +14,9 @@ scoreboard players operation @s omegaflowey.attack.bullets.total = #omegaflowey.
 
 # Randomize position to summon bullet at
 execute store result score @s omegaflowey.attack.bullets.position.x run random value -800..800
-scoreboard players operation @s omegaflowey.attack.bullets.position.x += #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.attack.bullets.position.x += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 scoreboard players set @s omegaflowey.attack.bullets.position.z -750
-scoreboard players operation @s omegaflowey.attack.bullets.position.z += #omegaflowey.bossfight.summit.origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.attack.bullets.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 
 # Randomize initial yaw of bullets
 execute store result score @s omegaflowey.math.0 run random value 0..1

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/loop/summon_bullet.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/loop/summon_bullet.mcfunction
@@ -3,13 +3,13 @@ execute if score @s omegaflowey.attack.bullets.count matches 0 run scoreboard pl
 execute unless score @s omegaflowey.attack.bullets.count matches 0 run scoreboard players set #omegaflowey.summon.tag_variant omegaflowey.global.flag 1
 
 # bullet head (begin animation)
-$execute if score @s omegaflowey.attack.bullets.count matches 0 run function omegaflowey.entity:directorial/boss_fight/summit/origin/at/y { \
+$execute if score @s omegaflowey.attack.bullets.count matches 0 run function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/y { \
   command: "execute positioned $(x) ~-4.0 $(z) run function animated_java:omegaflowey_dentata_snake_ball/summon { \
     args: { animation: 'omegaflowey_roll_bite', start_animation: true } \
   }" \
 }
 # bullet tail
-$execute unless score @s omegaflowey.attack.bullets.count matches 0 run function omegaflowey.entity:directorial/boss_fight/summit/origin/at/y { \
+$execute unless score @s omegaflowey.attack.bullets.count matches 0 run function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/y { \
   command: "execute positioned $(x) ~-4.0 $(z) run function animated_java:omegaflowey_dentata_snake_ball/summon/tail" \
 }
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/executor/loop/indicator/presummon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/executor/loop/indicator/presummon.mcfunction
@@ -13,7 +13,7 @@ scoreboard players operation @s omegaflowey.attack.position.y = #omegaflowey.bos
 scoreboard players remove @s omegaflowey.attack.position.y 400
 
 # Randomize z-position to summon indicator at
-execute store result score @s omegaflowey.attack.position.z run random value -3200..-900
+execute store result score @s omegaflowey.attack.position.z run random value 900..3200
 scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 
 # Store new position and yaw

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/executor/loop/indicator/presummon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/executor/loop/indicator/presummon.mcfunction
@@ -1,5 +1,5 @@
 # randomize x-position
-scoreboard players operation @s omegaflowey.attack.position.x = #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.attack.position.x = #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 execute store result score @s omegaflowey.math.0 run random value 0..1
 execute if score @s omegaflowey.math.0 matches 0 run scoreboard players remove @s omegaflowey.attack.position.x 1400
 execute if score @s omegaflowey.math.0 matches 1 run scoreboard players add @s omegaflowey.attack.position.x 1400
@@ -9,12 +9,12 @@ scoreboard players set @s omegaflowey.attack.indicator.yaw -9000
 execute if score @s omegaflowey.math.0 matches 1 run scoreboard players set @s omegaflowey.attack.indicator.yaw 9000
 
 # y-position
-scoreboard players operation @s omegaflowey.attack.position.y = #omegaflowey.bossfight.summit.origin.y omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.attack.position.y = #omegaflowey.bossfight.vanilla.origin.y omegaflowey.global.flag
 scoreboard players remove @s omegaflowey.attack.position.y 400
 
 # Randomize z-position to summon indicator at
 execute store result score @s omegaflowey.attack.position.z run random value -3200..-900
-scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.summit.origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 
 # Store new position and yaw
 execute store result storage omegaflowey:attack.finger-guns x double 0.01 run scoreboard players get @s omegaflowey.attack.position.x

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/indicator/loop/laser/summon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/finger-guns/indicator/loop/laser/summon.mcfunction
@@ -1,5 +1,5 @@
 # Summon and initialize laser
-$function omegaflowey.entity:directorial/boss_fight/summit/origin/at/x { \
+$function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/x { \
   command: "execute positioned ~ ~0.5 $(z) run function animated_java:omegaflowey_finger_gun_laser/summon { args: {} }" \
 }
 execute on passengers if entity @s[type=minecraft:marker, tag=aj.data] run \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
@@ -5,7 +5,7 @@
 execute if score @s omegaflowey.attack.clock.i matches 0 run scoreboard players add #omegaflowey.attack.friendliness-pellets omegaflowey.attack.indicator.clock.delay 6
 
 # Summon indicator
-$execute at $(active_player_uuid) run function omegaflowey.entity:directorial/boss_fight/summit/origin/at/y { \
+$execute at $(active_player_uuid) run function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/y { \
   command: "execute positioned ~ ~-4.0 ~ run function omegaflowey.entity:hostile/omega-flowey/attack/friendliness-pellets/indicator/summon" \
 }
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/bullet/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/bullet/loop.mcfunction
@@ -8,7 +8,7 @@ execute if entity @s[tag=!cant-damage] run function omegaflowey.entity:utils/dam
 
 # Check if inside arena
 scoreboard players set @s omegaflowey.math.0 0
-function omegaflowey.entity:directorial/boss_fight/summit/origin/at/position { \
+function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/position { \
   command: "execute positioned ~-25.0 ~-5.0 ~-7.5 if entity @s[dx=50,dy=10,dz=-23] run \
     scoreboard players set @s omegaflowey.math.0 1\
   " \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/bullet/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/bullet/loop.mcfunction
@@ -9,7 +9,7 @@ execute if entity @s[tag=!cant-damage] run function omegaflowey.entity:utils/dam
 # Check if inside arena
 scoreboard players set @s omegaflowey.math.0 0
 function omegaflowey.entity:directorial/boss_fight/vanilla/origin/at/position { \
-  command: "execute positioned ~-25.0 ~-5.0 ~-7.5 if entity @s[dx=50,dy=10,dz=-23] run \
+  command: "execute positioned ~-25.0 ~-5.0 ~7.5 if entity @s[dx=50,dy=10,dz=23] run \
     scoreboard players set @s omegaflowey.math.0 1\
   " \
 }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_bullet_position.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_bullet_position.mcfunction
@@ -25,7 +25,7 @@ execute store result score @s omegaflowey.attack.position.y run random value -30
 scoreboard players operation @s omegaflowey.attack.position.y += #omegaflowey.bossfight.vanilla.origin.y omegaflowey.global.flag
 
 # Set z-position to summon bullet at
-scoreboard players set @s omegaflowey.attack.position.z -850
+scoreboard players set @s omegaflowey.attack.position.z 850
 scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 
 execute store result storage omegaflowey:attack.homing-vines x float 0.01 run scoreboard players get @s omegaflowey.attack.position.x

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_bullet_position.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_bullet_position.mcfunction
@@ -7,14 +7,14 @@ scoreboard players operation @s omegaflowey.attack.position.x += @s omegaflowey.
 # Bound `omegaflowey.attack.position.x` within arena
 # lower-bound
 scoreboard players set @s omegaflowey.math.0 -1800
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 execute store result storage omegaflowey:utils.math.max a int 1 run scoreboard players get @s omegaflowey.math.0
 execute store result storage omegaflowey:utils.math.max b int 1 run scoreboard players get @s omegaflowey.attack.position.x
 function omegaflowey.utils:math/max
 execute store result score @s omegaflowey.attack.position.x run data get storage omegaflowey:utils.math.max out
 # upper-bound
 scoreboard players set @s omegaflowey.math.0 1800
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 execute store result storage omegaflowey:utils.math.min a int 1 run scoreboard players get @s omegaflowey.math.0
 execute store result storage omegaflowey:utils.math.min b int 1 run scoreboard players get @s omegaflowey.attack.position.x
 function omegaflowey.utils:math/min
@@ -22,11 +22,11 @@ execute store result score @s omegaflowey.attack.position.x run data get storage
 
 # Randomize y-position to summon bullet at
 execute store result score @s omegaflowey.attack.position.y run random value -300..300
-scoreboard players operation @s omegaflowey.attack.position.y += #omegaflowey.bossfight.summit.origin.y omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.attack.position.y += #omegaflowey.bossfight.vanilla.origin.y omegaflowey.global.flag
 
 # Set z-position to summon bullet at
 scoreboard players set @s omegaflowey.attack.position.z -850
-scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.summit.origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 
 execute store result storage omegaflowey:attack.homing-vines x float 0.01 run scoreboard players get @s omegaflowey.attack.position.x
 execute store result storage omegaflowey:attack.homing-vines y float 0.01 run scoreboard players get @s omegaflowey.attack.position.y

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_indicator_position.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_indicator_position.mcfunction
@@ -7,14 +7,14 @@ scoreboard players operation @s omegaflowey.attack.position.x += @s omegaflowey.
 # Bound `omegaflowey.attack.position.x` within arena
 # lower-bound
 scoreboard players set @s omegaflowey.math.0 -1400
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 execute store result storage omegaflowey:utils.math.max a int 1 run scoreboard players get @s omegaflowey.math.0
 execute store result storage omegaflowey:utils.math.max b int 1 run scoreboard players get @s omegaflowey.attack.position.x
 function omegaflowey.utils:math/max
 execute store result score @s omegaflowey.attack.position.x run data get storage omegaflowey:utils.math.max out
 # upper-bound
 scoreboard players set @s omegaflowey.math.0 1400
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 execute store result storage omegaflowey:utils.math.min a int 1 run scoreboard players get @s omegaflowey.math.0
 execute store result storage omegaflowey:utils.math.min b int 1 run scoreboard players get @s omegaflowey.attack.position.x
 function omegaflowey.utils:math/min
@@ -24,7 +24,7 @@ execute store result score @s omegaflowey.attack.position.x run data get storage
 # we can see the blinking lane aboveground sometimes
 execute store result score @s omegaflowey.attack.position.y run data get entity @s Pos[1] 100
 scoreboard players set @s omegaflowey.math.0 400
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.y omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.y omegaflowey.global.flag
 execute store result storage omegaflowey:utils.math.min a int 1 run scoreboard players get @s omegaflowey.math.0
 execute store result storage omegaflowey:utils.math.min b int 1 run scoreboard players get @s omegaflowey.attack.position.y
 function omegaflowey.utils:math/min
@@ -39,14 +39,14 @@ scoreboard players operation @s omegaflowey.attack.position.z += @s omegaflowey.
 # Bound `omegaflowey.attack.position.z` within arena
 # lower-bound
 scoreboard players set @s omegaflowey.math.0 -3050
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 execute store result storage omegaflowey:utils.math.max a int 1 run scoreboard players get @s omegaflowey.math.0
 execute store result storage omegaflowey:utils.math.max b int 1 run scoreboard players get @s omegaflowey.attack.position.z
 function omegaflowey.utils:math/max
 execute store result score @s omegaflowey.attack.position.z run data get storage omegaflowey:utils.math.max out
 # upper-bound
 scoreboard players set @s omegaflowey.math.0 -950
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 execute store result storage omegaflowey:utils.math.min a int 1 run scoreboard players get @s omegaflowey.math.0
 execute store result storage omegaflowey:utils.math.min b int 1 run scoreboard players get @s omegaflowey.attack.position.z
 function omegaflowey.utils:math/min

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_indicator_position.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_indicator_position.mcfunction
@@ -38,14 +38,14 @@ scoreboard players operation @s omegaflowey.attack.position.z += @s omegaflowey.
 
 # Bound `omegaflowey.attack.position.z` within arena
 # lower-bound
-scoreboard players set @s omegaflowey.math.0 -3050
+scoreboard players set @s omegaflowey.math.0 950
 scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 execute store result storage omegaflowey:utils.math.max a int 1 run scoreboard players get @s omegaflowey.math.0
 execute store result storage omegaflowey:utils.math.max b int 1 run scoreboard players get @s omegaflowey.attack.position.z
 function omegaflowey.utils:math/max
 execute store result score @s omegaflowey.attack.position.z run data get storage omegaflowey:utils.math.max out
 # upper-bound
-scoreboard players set @s omegaflowey.math.0 -950
+scoreboard players set @s omegaflowey.math.0 3050
 scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag
 execute store result storage omegaflowey:utils.math.min a int 1 run scoreboard players get @s omegaflowey.math.0
 execute store result storage omegaflowey:utils.math.min b int 1 run scoreboard players get @s omegaflowey.attack.position.z

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize.mcfunction
@@ -14,7 +14,7 @@ scoreboard players operation @s omegaflowey.attack.bullets.remaining = @s omegaf
 # Determine if this indicator belongs to the right/left eye
 execute store result score @s omegaflowey.math.0 run data get entity @s Pos[0] 100
 scoreboard players operation @s omegaflowey.math.0 -= #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
-execute if score @s omegaflowey.math.0 matches 0.. run tag @s add indicator.left
+execute unless score @s omegaflowey.math.0 matches 0.. run tag @s add indicator.left
 
 # Face nearest player
 function omegaflowey.entity:hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize/face_player

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize.mcfunction
@@ -13,7 +13,7 @@ scoreboard players operation @s omegaflowey.attack.bullets.remaining = @s omegaf
 
 # Determine if this indicator belongs to the right/left eye
 execute store result score @s omegaflowey.math.0 run data get entity @s Pos[0] 100
-scoreboard players operation @s omegaflowey.math.0 -= #omegaflowey.bossfight.summit.origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 -= #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 execute if score @s omegaflowey.math.0 matches 0.. run tag @s add indicator.left
 
 # Face nearest player

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/shared/run_if_outside_arena_volume.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/shared/run_if_outside_arena_volume.mcfunction
@@ -1,2 +1,2 @@
 # NOTE: TAG_SUMMIT_HARDCODED_ARENA_VOLUME
-$execute unless entity @s[x=-186, dx=61, y=10, dy=46, z=47, dz=60] run $(command)
+$execute unless entity @s[x=-33, dx=61, y=25, dy=46, z=-20, dz=60] run $(command)


### PR DESCRIPTION
most attacks have been migrated to be functional again with the vanilla world:

- bomb
- dentata-snakes
- finger-guns
- friendliness-pellets
- homing-vines
- x-bullets-lower
- x-bullets-upper

---

attacks still to be migrated:

- flies
- homing-vines-save-states
- x-bullets-upper-save-states
- (soul events)