### PR TITLE
⚔️ convert flies summon coords to relative and shrink bounds

### DIFF
--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/origin/at/x.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/origin/at/x.mcfunction
@@ -1,2 +1,2 @@
 # NOTE: TAG_VANILLA_HARDCODED
-$execute positioned 0.5 ~ ~ run $(command)
+$execute positioned 0.51 ~ ~ run $(command)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/origin/setup.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/origin/setup.mcfunction
@@ -1,4 +1,6 @@
 # NOTE: TAG_VANILLA_HARDCODED
-scoreboard players set #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag 050
+# we offset X by 0.01 because otherwise Minecraft autocorrects and messes up X-summons that
+# happen to be intended for `x: <int>.0` coordinates
+scoreboard players set #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag 051
 scoreboard players set #omegaflowey.bossfight.vanilla.origin.y omegaflowey.global.flag 3700
 scoreboard players set #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag -1250

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/bullet/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/bullet/initialize.mcfunction
@@ -3,7 +3,7 @@ scoreboard players set @s omegaflowey.attack.clock.i -1
 scoreboard players operation @s omegaflowey.attack.speed.z = #omegaflowey.attack.flies omegaflowey.attack.speed.z
 
 # Copy group id from indicator
-function omegaflowey.entity:group/copy with storage omegaflowey:attack.flies group_id
+function omegaflowey.entity:group/copy with storage omegaflowey:attack.flies
 
 # Face indicator (venus fly trap)
 function omegaflowey.entity:group/start

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/executor/initialize/indicator/presummon/flipped.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/executor/initialize/indicator/presummon/flipped.mcfunction
@@ -1,7 +1,9 @@
 function omegaflowey.entity:hostile/omega-flowey/attack/flies/executor/initialize/indicator/presummon/normal
 
 # flip x
+scoreboard players operation @s omegaflowey.attack.position.x -= #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 scoreboard players operation @s omegaflowey.attack.position.x *= #omegaflowey.const.-1 omegaflowey.math.const
+scoreboard players operation @s omegaflowey.attack.position.x += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 
 # flip yaw
 scoreboard players operation @s omegaflowey.attack.indicator.yaw *= #omegaflowey.const.-1 omegaflowey.math.const

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/executor/initialize/indicator/presummon/normal.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/executor/initialize/indicator/presummon/normal.mcfunction
@@ -1,10 +1,14 @@
-# x: 20.00
-scoreboard players set @s omegaflowey.attack.position.x 2000
+# x: +10.5
+scoreboard players set @s omegaflowey.attack.position.x 1150
+scoreboard players operation @s omegaflowey.attack.position.x += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 
 # face opposite corner of arena
-scoreboard players set @s omegaflowey.attack.indicator.yaw 11500
+scoreboard players set @s omegaflowey.attack.indicator.yaw 13080
 
-# y-position will summon at y: 33.00
-scoreboard players set @s omegaflowey.attack.position.y 3300
-# z-position will summon at z: 17.00
-scoreboard players set @s omegaflowey.attack.position.z 1700
+# y-position will summon at y: -4.0
+scoreboard players set @s omegaflowey.attack.position.y -400
+scoreboard players operation @s omegaflowey.attack.position.y += #omegaflowey.bossfight.vanilla.origin.y omegaflowey.global.flag
+
+# z-position will summon at z: +29.5
+scoreboard players set @s omegaflowey.attack.position.z 2950
+scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/presummon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/presummon.mcfunction
@@ -6,8 +6,9 @@ execute if score @s omegaflowey.math.0 matches 47..95 run function omegaflowey.e
 # otherwise (4% chance) the bullet spawns along the bottom wall
 execute if score @s omegaflowey.math.0 matches 96..99 run function omegaflowey.entity:hostile/omega-flowey/attack/flies/indicator/loop/bullet/presummon/along_bottom
 
-# y: 34.50
-scoreboard players set @s omegaflowey.attack.position.y 3450
+# y: -3.50
+scoreboard players set @s omegaflowey.attack.position.y -350
+scoreboard players operation @s omegaflowey.attack.position.y += #omegaflowey.bossfight.vanilla.origin.y omegaflowey.global.flag
 
 execute store result storage omegaflowey:attack.flies x double 0.01 run scoreboard players get @s omegaflowey.attack.position.x
 execute store result storage omegaflowey:attack.flies y double 0.01 run scoreboard players get @s omegaflowey.attack.position.y

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/presummon/along_bottom.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/presummon/along_bottom.mcfunction
@@ -1,6 +1,8 @@
-# x: -22.00..17.00
-execute store result score @s omegaflowey.attack.position.x run random value -2200..1700
+# x: -14.00..+7.50
+execute store result score @s omegaflowey.attack.position.x run random value -1400..750
 execute if entity @s[tag=is_flipped] run scoreboard players operation @s omegaflowey.attack.position.x *= #omegaflowey.const.-1 omegaflowey.math.const
+scoreboard players operation @s omegaflowey.attack.position.x += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 
-# z: 20.00
-scoreboard players set @s omegaflowey.attack.position.z 2000
+# z: +32.50
+scoreboard players set @s omegaflowey.attack.position.z 3250
+scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/presummon/along_side.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/presummon/along_side.mcfunction
@@ -1,6 +1,8 @@
-# x: -23.00
-scoreboard players set @s omegaflowey.attack.position.x -2300
+# x: -15.00
+scoreboard players set @s omegaflowey.attack.position.x -1500
 execute if entity @s[tag=is_flipped] run scoreboard players operation @s omegaflowey.attack.position.x *= #omegaflowey.const.-1 omegaflowey.math.const
+scoreboard players operation @s omegaflowey.attack.position.x += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 
-# z: -4.00..19.00
-execute store result score @s omegaflowey.attack.position.z run random value -400..1900
+# z: +8.50..+31.50
+execute store result score @s omegaflowey.attack.position.z run random value 850..3150
+scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/presummon/along_top.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/presummon/along_top.mcfunction
@@ -1,5 +1,7 @@
-# x: -22.00..22.00
-execute store result score @s omegaflowey.attack.position.x run random value -2200..2200
+# x: +/- 14.00
+execute store result score @s omegaflowey.attack.position.x run random value -1400..1400
+scoreboard players operation @s omegaflowey.attack.position.x += #omegaflowey.bossfight.vanilla.origin.x omegaflowey.global.flag
 
-# z: -5.00
-scoreboard players set @s omegaflowey.attack.position.z -500
+# z: +7.50
+scoreboard players set @s omegaflowey.attack.position.z 750
+scoreboard players operation @s omegaflowey.attack.position.z += #omegaflowey.bossfight.vanilla.origin.z omegaflowey.global.flag

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -106,7 +106,7 @@ module.exports = {
       world: {
         default: 'nps sync.world.up',
         down: `node ./package-scripts/sync-world --down ${worldSyncArgs}`,
-        up: `node ./package-scripts/sync-world --up ${worldSyncArgs}"`,
+        up: `node ./package-scripts/sync-world --up ${worldSyncArgs}`,
       },
       summit: {
         default: 'nps sync.summit.up',


### PR DESCRIPTION

For Smithed Summit 2024, we skipped converting the `flies` attack to use relative coordinates + new arena bounds since it wasn't in the demo.

This PR updates the attack to use coordinates relative to the vanilla bossfight origin and shrinks its bounds to be like the rest of the attacks.

---

## Reproducing

```mcfunction
function _:attack/flies
```
