### PR TITLE
🐛 fix attack sounds not playing in vanilla map

### DIFF
--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/shared/run_as_active_player_or_spectator.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/shared/run_as_active_player_or_spectator.mcfunction
@@ -1,5 +1,7 @@
-# NOTE: TAG_SUMMIT_HARDCODED_GLOBAL_VOLUME
+# # NOTE: TAG_SUMMIT_HARDCODED_GLOBAL_VOLUME
+#   as @a[x=-186, dx=91, y=10, dy=95, z=12, dz=95] \
+    unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] \
+
 $execute \
-  as @a[x=-186, dx=91, y=10, dy=95, z=12, dz=95] \
-  unless entity @s[tag=!omegaflowey.player.fighting_flowey, tag=!omegaflowey.player.room.spectator_box] \
+  as @a \
   run $(command)


### PR DESCRIPTION
- just temp disable the volume selector that was tuned for Summit