### PR TITLE
👻 fix soul events `0` and `5` from summit work

### DIFF
--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/setup.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/setup.mcfunction
@@ -1,5 +1,5 @@
 function omegaflowey.entity:directorial/boss_fight/vanilla/origin/setup
-# function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/setup
+function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/setup
 
 # function omegaflowey.entity:directorial/boss_fight/summit/player/queue/reset
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at.mcfunction
@@ -1,0 +1,11 @@
+$function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/yaw { \
+  command: 'function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/pitch { \
+    command: \'function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/x { \
+      command: \\\'function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/y { \
+        command: \\\\\\\'function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/z { \
+          command: "$(command)" \
+        }\\\\\\\' \
+      }\\\' \
+    }\' \
+  }' \
+}

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/pitch.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/pitch.mcfunction
@@ -1,0 +1,2 @@
+# NOTE: TAG_VANILLA_HARDCODED
+$execute rotated ~ 0 run $(command)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/position.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/position.mcfunction
@@ -1,0 +1,7 @@
+$function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/x { \
+  command: 'function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/y { \
+    command: \'function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/z { \
+      command: "$(command)" \
+    }\' \
+  }' \
+}

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/x.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/x.mcfunction
@@ -1,0 +1,2 @@
+# NOTE: TAG_VANILLA_HARDCODED
+$execute positioned 0.51 ~ ~ run $(command)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/y.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/y.mcfunction
@@ -1,0 +1,3 @@
+# NOTE: player should have y-coord of -4 blocks from Origin's Y coord
+# NOTE: TAG_VANILLA_HARDCODED
+$execute positioned ~ 37.0 ~ run $(command)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/yaw.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/yaw.mcfunction
@@ -1,0 +1,2 @@
+# NOTE: TAG_VANILLA_HARDCODED
+$execute rotated 180 ~ run $(command)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/z.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/z.mcfunction
@@ -1,0 +1,2 @@
+# NOTE: TAG_VANILLA_HARDCODED
+$execute positioned ~ ~ 21.5 run $(command)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/z.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/at/z.mcfunction
@@ -1,2 +1,2 @@
 # NOTE: TAG_VANILLA_HARDCODED
-$execute positioned ~ ~ 21.5 run $(command)
+$execute positioned ~ ~ -87.5 run $(command)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/setup.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/setup.mcfunction
@@ -1,0 +1,6 @@
+# NOTE: TAG_VANILLA_HARDCODED
+# we offset X by 0.01 because otherwise Minecraft autocorrects and messes up X-summons that
+# happen to be intended for `x: <int>.0` coordinates
+scoreboard players set #omegaflowey.bossfight.vanilla.soul_origin.x omegaflowey.global.flag 051
+scoreboard players set #omegaflowey.bossfight.vanilla.soul_origin.y omegaflowey.global.flag 3700
+scoreboard players set #omegaflowey.bossfight.vanilla.soul_origin.z omegaflowey.global.flag 2150

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/setup.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/setup.mcfunction
@@ -3,4 +3,4 @@
 # happen to be intended for `x: <int>.0` coordinates
 scoreboard players set #omegaflowey.bossfight.vanilla.soul_origin.x omegaflowey.global.flag 051
 scoreboard players set #omegaflowey.bossfight.vanilla.soul_origin.y omegaflowey.global.flag 3700
-scoreboard players set #omegaflowey.bossfight.vanilla.soul_origin.z omegaflowey.global.flag 2150
+scoreboard players set #omegaflowey.bossfight.vanilla.soul_origin.z omegaflowey.global.flag -8750

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/to_origin.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/directorial/boss_fight/vanilla/soul_origin/to_origin.mcfunction
@@ -1,0 +1,3 @@
+# assumes the executor is currently within the soul arena and wants to move to the main arena
+# NOTE: TAG_VANILLA_HARDCODED
+teleport @s ~ ~ ~-75.0

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/summon/soul/tv_screen.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/hostile/omega-flowey/summon/soul/tv_screen.mcfunction
@@ -1,5 +1,5 @@
 scoreboard players set #omegaflowey.summon.tag_variant omegaflowey.global.flag 2
-function omegaflowey.entity:directorial/boss_fight/summit/soul_origin/at { \
+function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at { \
   command: "execute positioned ~ ~12 ~-7 rotated ~ ~45 run function animated_java:omegaflowey_tv_screen/summon { args: {} }" \
 }
 scoreboard players set #omegaflowey.summon.tag_variant omegaflowey.global.flag 0

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/player/interacted/with_soul_act_button_locator.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/player/interacted/with_soul_act_button_locator.mcfunction
@@ -3,4 +3,4 @@ advancement revoke @s only omegaflowey.entity:player_interacted_with_soul_act_bu
 # only do stuff for the active bossfight player
 execute unless entity @s[tag=omegaflowey.player.fighting_flowey] run return 0
 
-function omegaflowey.entity:soul/soul_5/act_button/locator/player_interacted_with with storage omegaflowey:bossfight
+function omegaflowey.entity:soul/shared/act_button/locator/player_interacted_with with storage omegaflowey:bossfight

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/shared/run_if_outside_soul_arena_volume.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/shared/run_if_outside_soul_arena_volume.mcfunction
@@ -1,0 +1,2 @@
+# NOTE: TAG_VANILLA_HARDCODED
+$execute unless entity @s[x=-33.0, dx=67.0, y=25, dy=50.0, z=-120.0, dz=90.0] run $(command)

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/act_button/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/act_button/initialize.mcfunction
@@ -6,5 +6,7 @@ tag @s add act-button
 function gu:generate
 data modify storage omegaflowey:bossfight soul_act_button_uuid set from storage gu:main out
 
+execute if score #omegaflowey.soul.summon_type omegaflowey.global.flag matches 0 run \
+  function omegaflowey.entity:soul/soul_0/act_button/initialize with storage omegaflowey:soul.0.indicator
 execute if score #omegaflowey.soul.summon_type omegaflowey.global.flag matches 5 run \
   function omegaflowey.entity:soul/soul_5/act_button/initialize with storage omegaflowey:soul.5.indicator

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/act_button/locator/player_interacted_with.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/act_button/locator/player_interacted_with.mcfunction
@@ -1,0 +1,2 @@
+$execute as $(soul_act_button_uuid) run \
+  function omegaflowey.entity:soul/shared/act_button/locator/player_interacted_with/as_act_button

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/act_button/locator/player_interacted_with/as_act_button.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/act_button/locator/player_interacted_with/as_act_button.mcfunction
@@ -1,0 +1,5 @@
+# split based on soul phase
+execute if entity @s[tag=soul_0] run return run \
+  function omegaflowey.entity:soul/soul_0/act_button/locator/player_interacted_with with storage omegaflowey:bossfight
+execute if entity @s[tag=soul_5] run return run \
+  function omegaflowey.entity:soul/soul_5/act_button/locator/player_interacted_with with storage omegaflowey:bossfight

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/call_for_help_display/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/call_for_help_display/initialize.mcfunction
@@ -2,5 +2,7 @@ tag @s remove call-for-help-display-new
 
 data merge entity @s { brightness: { block: 15, sky: 0 } }
 
-execute if score #omegaflowey.soul.summon_type omegaflowey.global.flag matches 5 run \
+execute if score #omegaflowey.soul.summon_type omegaflowey.global.flag matches 0 run return run \
+  function omegaflowey.entity:soul/soul_0/call_for_help_display/initialize
+execute if score #omegaflowey.soul.summon_type omegaflowey.global.flag matches 5 run return run \
   function omegaflowey.entity:soul/soul_5/call_for_help_display/initialize

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/call_for_help_display/summon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/shared/call_for_help_display/summon.mcfunction
@@ -16,6 +16,7 @@ summon block_display ~ ~ ~ { \
       alignment:"center", \
       line_width:210, \
       default_background:false, \
+      Rotation: [180.0f, 0.0f], \
       transformation: { \
         left_rotation: [0.0f, 0.9914314f, -0.13062839f, 0.0f], \
         right_rotation: [0.0f, 0.0f, 0.0f, 1.0f], \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/initialize.mcfunction
@@ -1,2 +1,4 @@
-# Add tags
 tag @s add soul_0
+
+# Update tags on locator children
+function animated_java:omegaflowey_act_button/as_own_locator_entities { command: 'function omegaflowey.entity:soul/soul_0/act_button/initialize/locator' }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/initialize.mcfunction
@@ -1,8 +1,2 @@
 # Add tags
 tag @s add soul_0
-
-# Play rotate animation
-function animated_java:omegaflowey_act_button/animations/omegaflowey_rotate/play
-
-# Remove tags
-tag @s remove act-button-new

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/initialize/locator.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/initialize/locator.mcfunction
@@ -1,4 +1,4 @@
-tag @s add soul_5
+tag @s add soul_0
 
 # Copy to entity data for hitbox checks
 data modify entity @s data.soul_act_button_uuid set from storage omegaflowey:bossfight soul_act_button_uuid

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/locator.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/locator.mcfunction
@@ -1,2 +1,8 @@
-# only perform hitbox check if player(s) haven't yet touched the ACT button
-$execute if score #omegaflowey.soul.0.touched omegaflowey.soul.flag matches 0 positioned ~ ~-1 ~ if entity @a[distance=..$(radius),tag=omegaflowey.player.fighting_flowey] as @e[tag=soul_0,tag=aj.omegaflowey_act_button.root] run function omegaflowey.entity:soul/soul_0/act_button/touch
+# if player(s) have touched the ACT button, delete the locator
+execute if score #omegaflowey.soul.0.touched omegaflowey.soul.flag matches 1 run return run kill @s
+
+# otherwise, perform hitbox check with player hitbox
+$execute \
+  if entity @a[dx=0, dy=0, dz=0, tag=omegaflowey.player.fighting_flowey] \
+  as $(soul_act_button_uuid) run \
+  function omegaflowey.entity:soul/soul_0/act_button/touch with storage omegaflowey:soul.0

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/locator/player_interacted_with.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/locator/player_interacted_with.mcfunction
@@ -1,0 +1,4 @@
+# do nothing if player already touched the ACT button
+execute if score #omegaflowey.soul.0.touched omegaflowey.soul.flag matches 1 run return 0
+
+function omegaflowey.entity:soul/soul_0/act_button/touch with storage omegaflowey:soul.0

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/summon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/summon.mcfunction
@@ -1,5 +1,3 @@
-# Summon act button
-$execute positioned $(x) 34.5 $(z) rotated 0 0 run function animated_java:omegaflowey_act_button/summon { args: {} }
-
-# Initialize act button
-execute as @e[tag=act-button-new] at @s run function omegaflowey.entity:soul/soul_0/act_button/initialize
+# Summon and initialize act button
+scoreboard players set #omegaflowey.soul.summon_type omegaflowey.global.flag 0
+$execute positioned $(x) 34.5 $(z) rotated 0 0 run function animated_java:omegaflowey_act_button/summon { args: { animation: 'omegaflowey_rotate', start_animation: true } }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/touch.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/touch.mcfunction
@@ -4,6 +4,11 @@ scoreboard players set #omegaflowey.soul.0.touched omegaflowey.soul.flag 1
 # Apply yellow-highlighted variant
 function animated_java:omegaflowey_act_button/variants/selected/apply
 
+# Play select sound
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'playsound omega-flowey:soul.touch ambient @s ~ ~ ~ 10' \
+}
+
 # Summon and initialize call for help display
 scoreboard players set #omegaflowey.soul.summon_type omegaflowey.global.flag 0
 function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/position { \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/touch.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/act_button/touch.mcfunction
@@ -5,9 +5,10 @@ scoreboard players set #omegaflowey.soul.0.touched omegaflowey.soul.flag 1
 function animated_java:omegaflowey_act_button/variants/selected/apply
 
 # Summon and initialize call for help display
-function omegaflowey.entity:soul/shared/call_for_help_display/summon
-execute as @e[tag=omega-flowey-remastered, tag=call-for-help-display-new] run \
-  function omegaflowey.entity:soul/soul_0/call_for_help_display/initialize
+scoreboard players set #omegaflowey.soul.summon_type omegaflowey.global.flag 0
+function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/position { \
+  command: "execute positioned ~ ~7.0 ~9.5 run function omegaflowey.entity:soul/shared/call_for_help_display/summon" \
+}
 
 # TODO(36): transparent fade-out of `act_button` model?
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/call_for_help_display/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/call_for_help_display/initialize.mcfunction
@@ -1,3 +1,1 @@
 tag @s add soul_0
-
-function omegaflowey.entity:soul/shared/call_for_help_display/initialize

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/initialize/saved.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/initialize/saved.mcfunction
@@ -1,12 +1,9 @@
 # Update state flag
 scoreboard players set #omegaflowey.soul.0.saved omegaflowey.soul.flag 1
 
-# Stop event music
-stopsound @a record omega-flowey:music.soul.0
-
-# Play saved music + sound effect
-playsound omega-flowey:soul.saved record @a ~ ~ ~ 10 1
-playsound omega-flowey:soul.transition record @a ~ ~ ~ 10 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'execute at @s run function omegaflowey.entity:soul/soul_0/executor/initialize/saved/as_player' \
+}
 
 # Flash each player's screen
 execute as @a[tag=omegaflowey.player.fighting_flowey] at @s anchored eyes run particle minecraft:flash ^ ^ ^0.5

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/initialize/saved/as_player.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/initialize/saved/as_player.mcfunction
@@ -1,0 +1,6 @@
+# Stop event music
+stopsound @s record omega-flowey:music.soul.0
+
+# Play saved music + sound effect
+playsound omega-flowey:soul.saved record @s ~ ~ ~ 10 1
+playsound omega-flowey:soul.transition record @s ~ ~ ~ 10 1

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/loop.mcfunction
@@ -1,5 +1,5 @@
 # Loop logic for players
-execute as @a[tag=omegaflowey.player.fighting_flowey] run function omegaflowey.entity:soul/soul_0/executor/loop/as_player
+$execute as $(active_player_uuid) run function omegaflowey.entity:soul/soul_0/executor/loop/as_player
 
 scoreboard players add @s omegaflowey.soul.clock.i 1
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/play_music.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/executor/play_music.mcfunction
@@ -1,1 +1,3 @@
-playsound omega-flowey:music.soul.0 record @a ~ ~ ~ 10 1
+function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: \
+  'execute at @s run playsound omega-flowey:music.soul.0 record @s ~ ~ ~ 1 1' \
+}

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/locator/loop.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/locator/loop.mcfunction
@@ -1,2 +1,2 @@
-execute if entity @s[tag=aj.omegaflowey_act_button.locator] run function omegaflowey.entity:soul/soul_0/act_button/locator with entity @s data
+execute if entity @s[tag=aj.omegaflowey_act_button.locator] run function omegaflowey.entity:soul/soul_0/act_button/locator with storage omegaflowey:bossfight
 execute if entity @s[tag=aj.omegaflowey_soul_0_sword.locator] run function omegaflowey.entity:soul/soul_0/bullet/locator

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/tick.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_0/tick.mcfunction
@@ -1,5 +1,5 @@
 execute if entity @s[tag=act-button] run function omegaflowey.entity:soul/soul_0/act_button/loop
 execute if entity @s[tag=bandaid] run function omegaflowey.entity:soul/soul_0/bandaid/loop
 execute if entity @s[tag=soul-bullet] run function omegaflowey.entity:soul/soul_0/bullet/loop
-execute if entity @s[tag=soul-executor] run function omegaflowey.entity:soul/soul_0/executor/loop
+execute if entity @s[tag=soul-executor] run function omegaflowey.entity:soul/soul_0/executor/loop with storage omegaflowey:bossfight
 execute if entity @s[tag=soul-locator] run function omegaflowey.entity:soul/soul_0/locator/loop

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/act_button/initialize.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/act_button/initialize.mcfunction
@@ -6,9 +6,6 @@ scoreboard players set @s omegaflowey.soul.clock.i -1
 # Add tags
 tag @s add soul_5
 
-# Remove tags
-tag @s remove act-button-new
-
 # Store this UUID to a global storage for later reference
 function gu:generate
 data modify storage omegaflowey:soul.5 act_button_uuid set from storage gu:main out

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/act_button/touch.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/act_button/touch.mcfunction
@@ -14,7 +14,7 @@ function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: 
 # Summon and initialize call for help display
 scoreboard players set #omegaflowey.soul.summon_type omegaflowey.global.flag 5
 function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/position { \
-  command: "execute positioned ~ ~7.0 ~-9.5 run function omegaflowey.entity:soul/shared/call_for_help_display/summon" \
+  command: "execute positioned ~ ~7.0 ~9.5 run function omegaflowey.entity:soul/shared/call_for_help_display/summon" \
 }
 
 # TODO(36): transparent fade-out of `act_button` model?

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/act_button/touch.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/act_button/touch.mcfunction
@@ -13,7 +13,9 @@ function omegaflowey.entity:shared/run_as_active_player_or_spectator { command: 
 
 # Summon and initialize call for help display
 scoreboard players set #omegaflowey.soul.summon_type omegaflowey.global.flag 5
-function omegaflowey.entity:directorial/boss_fight/summit/soul_origin/at/position { command: "execute positioned ~ ~7.0 ~-9.5 run function omegaflowey.entity:soul/shared/call_for_help_display/summon" }
+function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/position { \
+  command: "execute positioned ~ ~7.0 ~-9.5 run function omegaflowey.entity:soul/shared/call_for_help_display/summon" \
+}
 
 # TODO(36): transparent fade-out of `act_button` model?
 

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/bullet/cleanup.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/bullet/cleanup.mcfunction
@@ -1,4 +1,4 @@
 # runs every tick on the bullet AJ model, terminating if it's outside the arena bounds
-function omegaflowey.entity:shared/run_if_outside_arena_volume { command: \
+function omegaflowey.entity:shared/run_if_outside_soul_arena_volume { command: \
   "function omegaflowey.entity:soul/soul_5/bullet/terminate" \
 }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/crosshair/summon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/crosshair/summon.mcfunction
@@ -1,5 +1,5 @@
 # Summon and initialize crosshair at random radius around this player (radius = 4 blocks)
-$function omegaflowey.entity:directorial/boss_fight/summit/soul_origin/at/y { \
+$function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/y { \
   command: "execute \
     rotated $(next_bullet_angle_from_player) 0 \
     positioned ^ ^ ^4 \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/terminate.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/executor/terminate.mcfunction
@@ -2,7 +2,6 @@ $execute as $(boss_fight_uuid) run function omegaflowey.entity:soul/soul_5/execu
 
 # NOTE: TAG_SUMMIT_HARDCODED_GLOBAL_VOLUME
 execute as @e[ \
-  x=-186, dx=91, y=10, dy=95, z=12, dz=95, \
   tag=soul_5, \
   tag=omega-flowey-remastered \
 ] run function omegaflowey.entity:soul/soul_5/executor/terminate/as_root

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/healer/cleanup.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/healer/cleanup.mcfunction
@@ -1,4 +1,4 @@
 # runs every tick on the AJ model, terminating if it's outside the arena bounds
-function omegaflowey.entity:shared/run_if_outside_arena_volume { command: \
+function omegaflowey.entity:shared/run_if_outside_soul_arena_volume { command: \
   "function omegaflowey.entity:soul/soul_5/healer/terminate" \
 }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/initialize/saved.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/initialize/saved.mcfunction
@@ -3,5 +3,5 @@ tag @s remove shaking
 
 # Return to starting position
 function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/position {\
-  command: "teleport @s ~ ~-3.9 ~-20.0" \
+  command: "teleport @s ~ ~-3.9 ~20.0" \
 }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/initialize/saved.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/initialize/saved.mcfunction
@@ -2,6 +2,6 @@
 tag @s remove shaking
 
 # Return to starting position
-function omegaflowey.entity:directorial/boss_fight/summit/soul_origin/at/position {\
+function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/position {\
   command: "teleport @s ~ ~-3.9 ~-20.0" \
 }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/loop/aiming/next_crosshair/randomize_yaw/check_valid.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/loop/aiming/next_crosshair/randomize_yaw/check_valid.mcfunction
@@ -1,7 +1,7 @@
 # this position is invalid if the placement is too close to the indicator
 scoreboard players set @s omegaflowey.math.bool 1
 
-$function omegaflowey.entity:directorial/boss_fight/summit/soul_origin/at/y { \
+$function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at/y { \
   command: "\
     execute \
       rotated $(next_bullet_angle_from_player) 0 positioned ^ ^ ^4 positioned ~ ~-3.9 ~ \

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/summon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/summon.mcfunction
@@ -1,4 +1,4 @@
 # Summon and initialize gun
-function omegaflowey.entity:directorial/boss_fight/summit/soul_origin/at { \
+function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at { \
   command: "execute positioned ~ ~-3.9 ~-20.0 run function animated_java:omegaflowey_soul_5_gun/summon { args: {} }" \
 }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/summon.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/indicator/summon.mcfunction
@@ -1,4 +1,4 @@
 # Summon and initialize gun
 function omegaflowey.entity:directorial/boss_fight/vanilla/soul_origin/at { \
-  command: "execute positioned ~ ~-3.9 ~-20.0 run function animated_java:omegaflowey_soul_5_gun/summon { args: {} }" \
+  command: "execute positioned ~ ~-3.9 ~20.0 run function animated_java:omegaflowey_soul_5_gun/summon { args: {} }" \
 }

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/shared/terminate_unless_in_region.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/shared/terminate_unless_in_region.mcfunction
@@ -1,8 +1,8 @@
 # x bounds
 scoreboard players set @s omegaflowey.math.0 -3200
 scoreboard players set @s omegaflowey.math.1 3200
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.soul_origin.x omegaflowey.global.flag
-scoreboard players operation @s omegaflowey.math.1 += #omegaflowey.bossfight.summit.soul_origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.soul_origin.x omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.1 += #omegaflowey.bossfight.vanilla.soul_origin.x omegaflowey.global.flag
 
 $execute store result score @s $(x_score) run data get entity @s Pos[0] 100
 $execute if score @s $(x_score) <= @s omegaflowey.math.0 run tag @s add should-terminate
@@ -11,8 +11,8 @@ $execute if score @s $(x_score) >= @s omegaflowey.math.1 run tag @s add should-t
 # z bounds
 scoreboard players set @s omegaflowey.math.0 -4150
 scoreboard players set @s omegaflowey.math.1 850
-scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.summit.soul_origin.z omegaflowey.global.flag
-scoreboard players operation @s omegaflowey.math.1 += #omegaflowey.bossfight.summit.soul_origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.soul_origin.z omegaflowey.global.flag
+scoreboard players operation @s omegaflowey.math.1 += #omegaflowey.bossfight.vanilla.soul_origin.z omegaflowey.global.flag
 
 $execute store result score @s $(z_score) run data get entity @s Pos[2] 100
 $execute if score @s $(z_score) <= @s omegaflowey.math.0 run tag @s add should-terminate

--- a/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/shared/terminate_unless_in_region.mcfunction
+++ b/datapacks/omegaflowey/data/omegaflowey.entity/function/soul/soul_5/shared/terminate_unless_in_region.mcfunction
@@ -9,8 +9,8 @@ $execute if score @s $(x_score) <= @s omegaflowey.math.0 run tag @s add should-t
 $execute if score @s $(x_score) >= @s omegaflowey.math.1 run tag @s add should-terminate
 
 # z bounds
-scoreboard players set @s omegaflowey.math.0 -4150
-scoreboard players set @s omegaflowey.math.1 850
+scoreboard players set @s omegaflowey.math.0 -850
+scoreboard players set @s omegaflowey.math.1 4150
 scoreboard players operation @s omegaflowey.math.0 += #omegaflowey.bossfight.vanilla.soul_origin.z omegaflowey.global.flag
 scoreboard players operation @s omegaflowey.math.1 += #omegaflowey.bossfight.vanilla.soul_origin.z omegaflowey.global.flag
 


### PR DESCRIPTION
makes the preexisting soul events `0` and `5` function properly again, after Smithed Summit 2024.

```mcfunction
function _:soul/0
function _:soul/5
```

---

also closes #132 