### PR TITLE
🔧 update spyglassrc `exclude` patterns

### DIFF
--- a/.spyglassrc.json
+++ b/.spyglassrc.json
@@ -2,10 +2,14 @@
   "env": {
     "exclude": [
       ".*",
-      "tmp",
-      "build",
+      "**/.yarn/**",
+      "**/node_modules/**",
+      "**/bin/**",
+      "**/build/**",
       "**/last_exported_hashes.json",
-      "datapacks/omegaflowey/data/*/test/",
+      "**/tmp/**",
+      "**/world.zip",
+      "**/datapacks/omegaflowey/data/*/test/**",
       "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.1\\1.20.1\\assets\\minecraft"
     ]
   }

--- a/datapacks/omegaflowey/data/_/function/active_player.mcfunction
+++ b/datapacks/omegaflowey/data/_/function/active_player.mcfunction
@@ -1,2 +1,1 @@
-function gu:generate
-data modify storage omegaflowey:bossfight active_player_uuid set from storage gu:main out
+function omegaflowey.entity:directorial/boss_fight/shared/player/set_active_player


### PR DESCRIPTION
- looking at the Spyglass logs locally, this decreased the `bind` phase from ~100s to ~1.5s.
- likely possible now due to various exclude improvements Spyglass has made since the last time this was configured
- now, test files are excluded properly and we won't get errors!