### PR TITLE
➕ add shader resourcepack dependency

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
     "seatonjiang.gitmoji-vscode",
     "shardulm94.trailing-spaces",
     "spgoding.datapack-language-server",
-    "ctf0.command-autolink"
+    "ctf0.command-autolink",
+    "slevesque.shader"
   ]
 }

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout.fsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout.fsh
@@ -1,0 +1,30 @@
+#version 150
+
+#moj_import <fog.glsl>
+#moj_import <emissive_utils.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightColor;
+in vec4 faceLightColor;
+in vec4 overlayColor;
+in vec2 texCoord0;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0);
+    color *= vertexColor * ColorModulator;
+    color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout.vsh
@@ -1,0 +1,39 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightColor;
+out vec4 faceLightColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.fsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.fsh
@@ -1,0 +1,30 @@
+#version 150
+
+#moj_import <fog.glsl>
+#moj_import <emissive_utils.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightColor;
+in vec4 faceLightColor;
+in vec4 overlayColor;
+in vec2 texCoord0;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0);
+    color *= vertexColor * ColorModulator;
+    color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.vsh
@@ -1,0 +1,39 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightColor;
+out vec4 faceLightColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.fsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.fsh
@@ -1,0 +1,30 @@
+#version 150
+
+#moj_import <fog.glsl>
+#moj_import <emissive_utils.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightColor;
+in vec4 faceLightColor;
+in vec4 overlayColor;
+in vec2 texCoord0;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0);
+    color *= vertexColor * ColorModulator;
+    color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.vsh
@@ -1,0 +1,39 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightColor;
+out vec4 faceLightColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_no_outline.fsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_no_outline.fsh
@@ -1,0 +1,26 @@
+#version 150
+
+#moj_import <fog.glsl>
+#moj_import <emissive_utils.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightColor;
+in vec4 faceLightColor;
+in vec2 texCoord0;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_no_outline.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_no_outline.vsh
@@ -1,0 +1,35 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightColor;
+out vec4 faceLightColor;
+out vec2 texCoord0;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
+    texCoord0 = UV0;
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_solid.fsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_solid.fsh
@@ -1,0 +1,29 @@
+#version 150
+
+#moj_import <fog.glsl>
+#moj_import <emissive_utils.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightColor;
+in vec4 faceLightColor;
+in vec4 overlayColor;
+in vec2 texCoord0;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
+    color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+    if(color.a < 0.1) discard;
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_solid.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_solid.vsh
@@ -1,0 +1,39 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightColor;
+out vec4 faceLightColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_translucent.fsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_translucent.fsh
@@ -1,0 +1,30 @@
+#version 150
+
+#moj_import <fog.glsl>
+#moj_import <emissive_utils.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightColor;
+in vec4 faceLightColor;
+in vec4 overlayColor;
+in vec2 texCoord0;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0);
+    color *= vertexColor * ColorModulator;
+    color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_translucent.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_translucent.vsh
@@ -1,0 +1,39 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightColor;
+out vec4 faceLightColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.fsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.fsh
@@ -1,0 +1,28 @@
+#version 150
+
+#moj_import <fog.glsl>
+#moj_import <emissive_utils.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightColor;
+in vec4 faceLightColor;
+in vec2 texCoord0;
+in vec2 texCoord1;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.vsh
@@ -1,0 +1,40 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in vec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightColor;
+out vec4 faceLightColor;
+out vec2 texCoord0;
+out vec2 texCoord1;
+out vec2 texCoord2;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
+    texCoord0 = UV0;
+    texCoord1 = UV1;
+    texCoord2 = UV2;
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.fsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.fsh
@@ -1,0 +1,28 @@
+#version 150
+
+#moj_import <fog.glsl>
+#moj_import <emissive_utils.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightColor;
+in vec4 faceLightColor;
+in vec2 texCoord0;
+in vec2 texCoord1;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
+    int alpha = int(round(textureLod(Sampler0, texCoord0, 0.0).a * 255.0));
+    color = make_emissive(color, lightColor, faceLightColor, alpha);
+    if(color.a < 0.1) discard;
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.vsh
@@ -1,0 +1,40 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in vec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightColor;
+out vec4 faceLightColor;
+out vec2 texCoord0;
+out vec2 texCoord1;
+out vec2 texCoord2;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = Color;
+    lightColor = minecraft_sample_lightmap(Sampler2, UV2);
+    faceLightColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, vec4(1.0));
+    texCoord0 = UV0;
+    texCoord1 = UV1;
+    texCoord2 = UV2;
+}

--- a/resourcepack/assets/minecraft/shaders/include/emissive_utils.glsl
+++ b/resourcepack/assets/minecraft/shaders/include/emissive_utils.glsl
@@ -1,0 +1,145 @@
+#version 150
+
+// Checking for the exact alpha value breaks things, so I use this function to cut down on space while also making it work better.
+
+bool compare_floats(float a, float b) {
+	
+	float targetLess = a - 0.01;
+	float targetMore = a + 0.01;
+	return (b > targetLess && b < targetMore);
+	
+}
+
+// For cases in which you want something to have a lower light level, but still be bright when in light.
+
+vec4 apply_partial_emissivity(vec4 inputColor, vec4 originalLightColor, vec3 minimumLightColor) {
+    
+    vec4 newLightColor = originalLightColor;
+    newLightColor.r = max(originalLightColor.r, minimumLightColor.r);
+    newLightColor.g = max(originalLightColor.g, minimumLightColor.g);
+    newLightColor.b = max(originalLightColor.b, minimumLightColor.b);
+    return inputColor * newLightColor;
+    
+}
+
+
+// Gets the dimension that an object is in, -1 for The Nether, 0 for The Overworld, 1 for The End.
+
+float get_dimension(vec4 minLightColor) {
+    
+    if (minLightColor.r == minLightColor.g && minLightColor.g == minLightColor.b) return 0.0; // Shadows are grayscale in The Overworld
+    if (minLightColor.r > minLightColor.g) return -1.0; // Shadows are more red in The Nether
+    
+    return 1.0; // Shadows are slightly green in The End
+}
+
+// Gets the face lighting of a block. Credits to Venaxsys for the original function.
+
+vec4 get_block_face_lighting(vec3 normal, float dimension) { 
+    
+    vec4 faceLighting = vec4(1.0, 1.0, 1.0, 1.0);
+    vec3 absNormal = abs(normal);
+    float top = 229.0 / 255.0;
+    float bottom = 127.0 / 255.0;
+    float east = 153.0 / 255.0;
+    float north = 204.0 / 255.0;
+    
+    // Top (only required in the Nether)
+    if (normal.y > normal.z && normal.y > normal.x && compare_floats(dimension, -1.0)) faceLighting = vec4(top, top, top, 1.0); // It's not really checking the alpha but I'm too stubborn to change the function name
+    
+    // Bottom
+    if (normal.y < normal.z && normal.y < normal.x && !compare_floats(dimension, -1.0)) faceLighting = vec4(bottom, bottom, bottom, 1.0);
+    else if (normal.y < normal.z && normal.y < normal.x && compare_floats(dimension, -1.0)) faceLighting = vec4(top, top, top, 1.0);
+
+    // East-West
+    if (absNormal.x > absNormal.z && absNormal.x > absNormal.y) faceLighting = vec4(east, east, east, 1.0);
+
+    // North-South
+    if (absNormal.z > absNormal.x && absNormal.z > absNormal.y) faceLighting = vec4(north, north, north, 1.0);
+
+    return faceLighting;
+}
+
+
+// Checks if the face should have lighting.
+
+bool face_lighting_check(int inputAlpha) {
+
+    if (inputAlpha == 254) return false; // Checks for alpha 254, and returns that this face should not be lit. Used for emissiveness
+    if (inputAlpha == 253) return false; // Checks for alpha 253, and returns that this face should not be lit. Used for Shade false, non-emissive
+
+    
+    if (inputAlpha == 1) return false; // Checks for low alpha levels, and returns that this face should not be lit. Used for transparent Shade false, non-emissive
+    if (inputAlpha == 2) return false;
+    if (inputAlpha == 3) return false;
+    if (inputAlpha == 4) return false;
+    if (inputAlpha == 5) return false;
+    if (inputAlpha == 6) return false;
+    if (inputAlpha == 7) return false;
+    if (inputAlpha == 8) return false;
+
+    if (inputAlpha == 9) return false; // Checks for low alpha levels, and returns that this face should not be lit. Used for transparent emissiveness
+    if (inputAlpha == 10) return false;
+    if (inputAlpha == 11) return false;
+    if (inputAlpha == 12) return false;
+    if (inputAlpha == 13) return false;
+    if (inputAlpha == 14) return false;
+    if (inputAlpha == 15) return false;
+    if (inputAlpha == 16) return false;
+
+    return true; // A face should be lit by default
+}
+
+
+// Makes sure transparent things don't become solid and vice versa.
+
+float remap_alpha(float inputAlpha) {
+    
+    if (inputAlpha == 254) return 255.0; // Checks for alpha 252 and converts all pixels of that to alpha 255. Used for emissiveness
+    if (inputAlpha == 253) return 255.0; // Checks for alpha 252 and converts all pixels of that to alpha 255. Used for Shade false, non-emissive
+    
+    
+    if (inputAlpha == 1) return 16.0; // Checks for low alpha levels and converts all pixels of that to the respective transparency value. Used for transparent Shade false, non-emissive
+    if (inputAlpha == 2) return 48.0;
+    if (inputAlpha == 3) return 80.0;
+    if (inputAlpha == 4) return 112.0;
+    if (inputAlpha == 5) return 144.0;
+    if (inputAlpha == 6) return 176.0;
+    if (inputAlpha == 7) return 208.0;
+    if (inputAlpha == 8) return 240.0;    
+
+    if (inputAlpha == 9) return 16.0; // Checks for low alpha levels and converts all pixels of that to the respective transparency value. Used for transparent emissiveness
+    if (inputAlpha == 10) return 48.0;
+    if (inputAlpha == 11) return 80.0;
+    if (inputAlpha == 12) return 112.0;
+    if (inputAlpha == 13) return 144.0;
+    if (inputAlpha == 14) return 176.0;
+    if (inputAlpha == 15) return 208.0;
+    if (inputAlpha == 16) return 240.0;
+    
+    return inputAlpha; // If a pixel doesn't need to have its alpha changed then it simply does not change.
+}
+
+
+// The meat and bones of the pack, does all the work for making things emissive.
+
+vec4 make_emissive(vec4 inputColor, vec4 lightColor, vec4 faceLightColor, int inputAlpha) {
+
+    if(face_lighting_check(inputAlpha)) inputColor *= faceLightColor; // Applies the face lighting if the face should be lit
+    inputColor.a = remap_alpha(inputAlpha) / 255.0; // Remap the alpha value
+
+    if (inputAlpha == 254) return inputColor; // Checks for alpha 254 and just returns the input color if it is. Used for emissiveness
+
+    if (inputAlpha == 9) return inputColor; // Checks for low alpha and just returns the input color if it is. Used for transparent emissiveness
+    if (inputAlpha == 10) return inputColor;
+    if (inputAlpha == 11) return inputColor;
+    if (inputAlpha == 12) return inputColor;
+    if (inputAlpha == 13) return inputColor;
+    if (inputAlpha == 14) return inputColor;
+    if (inputAlpha == 15) return inputColor;
+    if (inputAlpha == 16) return inputColor;
+
+    // if (inputAlpha == 251) return apply_partial_emissivity(inputColor, lightColor, vec3(0.411, 0.345, 0.388)); // Possibility for partial emissiveness
+    
+    return inputColor * lightColor; // If none of the pixels are supposed to be emissive, then it adds the light.
+}


### PR DESCRIPTION
- added from a modified version of https://github.com/ShockMicro/VanillaDynamicEmissives
  - version i have added here was whatever Smithed Summit 2024 used
  - not sure what diffs (if any) there are with the above link but it's probably similar
- all this does is make it so certain pixel opacities render as emissive/emissive+transparent. used for super bright monitor screens, like the flowey TV
- extension https://marketplace.visualstudio.com/items?itemName=slevesque.shader for syntax highlighting of `.glsl`